### PR TITLE
Update README with more OS packages needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone --recursive http://github.com/sifive/freedom-e-sdk.git
 
 Ubuntu packages needed:
 
-	$ sudo apt-get install autoconf automake libmpc-dev libmpfr-dev libgmp-dev gawk bison flex texinfo libtool libusb-1.0-0-dev
+	$ sudo apt-get install autoconf automake libmpc-dev libmpfr-dev libgmp-dev gawk bison flex texinfo libtool libusb-1.0-0-dev make g++
 
 Next, build the tools:
 


### PR DESCRIPTION
A bare ubuntu-16.04.1-server installation could not run `make tools`
without these packages.