### PR TITLE
Add libexpat1-dev to the required packages list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone --recursive http://github.com/sifive/freedom-e-sdk.git
 
 Ubuntu packages needed:
 
-	$ sudo apt-get install autoconf automake libmpc-dev libmpfr-dev libgmp-dev gawk bison flex texinfo libtool libusb-1.0-0-dev make g++ pkg-config
+	$ sudo apt-get install autoconf automake libmpc-dev libmpfr-dev libgmp-dev gawk bison flex texinfo libtool libusb-1.0-0-dev make g++ pkg-config libexpat1-dev
 
 Next, build the tools:
 


### PR DESCRIPTION
libexpat1-dev is required in order for OpenOCD to pass GDB an XML description of the memory layout. This allows GDB to recognize regions of memory as being in Flash and therefore need a different way to read/write/set breakpoints in them.