### PR TITLE
Enable FPU in MSTATUS CSR during init

### DIFF
--- a/bsp/env/freedom-e300-hifive1/init.c
+++ b/bsp/env/freedom-e300-hifive1/init.c
@@ -182,6 +182,7 @@ void _init()
   printf("core freq at %d Hz\n", get_cpu_freq());
 
   write_csr(mtvec, &handle_trap);
+  write_csr(mstatus, MSTATUS_FS); // enable FPU
 
   _exit(main(0, NULL));
 }

--- a/bsp/env/freedom-e300-hifive1/init.c
+++ b/bsp/env/freedom-e300-hifive1/init.c
@@ -182,7 +182,10 @@ void _init()
   printf("core freq at %d Hz\n", get_cpu_freq());
 
   write_csr(mtvec, &handle_trap);
-  write_csr(mstatus, MSTATUS_FS); // enable FPU
+  if (read_csr(misa) & (1 << ('F' - 'A'))) { // if F extension is present
+    write_csr(mstatus, MSTATUS_FS); // allow FPU instructions without trapping
+    write_csr(fcsr, 0); // initialize rounding mode, undefined at reset
+  }
 
   _exit(main(0, NULL));
 }


### PR DESCRIPTION
This way, chips with FPU can run FPU instructions without taking
exceptions.

I've confirmed that dhrystone still runs successfully even on chips
with no FPU.