### PR TITLE
hifive1: Update OpenOCD Config script to optionally allow pulsing SRST

### DIFF
--- a/bsp/env/freedom-e300-hifive1/openocd.cfg
+++ b/bsp/env/freedom-e300-hifive1/openocd.cfg
@@ -5,7 +5,12 @@ ftdi_device_desc "Dual RS232-HS"
 ftdi_vid_pid 0x0403 0x6010
 
 ftdi_layout_init 0x0008 0x001b
-ftdi_layout_signal nSRST -oe 0x0020
+ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
+
+#Reset Stretcher logic on FE310 is ~1 second long
+#This doesn't apply if you use
+# ftdi_set_signal, but still good to document
+adapter_nsrst_delay 1500
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
@@ -14,8 +19,16 @@ set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 $_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
 
-flash bank my_first_flash fespi 0x20000000 0 0 0 $_TARGETNAME
+flash bank onboard_spi_flash fespi 0x20000000 0 0 0 $_TARGETNAME
 init
-#reset
+#reset -- This type of reset is not implemented yet
+if {[ info exists pulse_srst]} {
+  ftdi_set_signal nSRST 0
+  ftdi_set_signal nSRST z
+  #Wait for the reset stretcher
+  #It will work without this, but
+  #will incur lots of delays for later commands.
+  sleep 1500
+}	
 halt
 flash protect 0 64 last off


### PR DESCRIPTION
By passing in '-c set pulse_srst' to OpenOCD command line, OpenOCD will make sure the chip is reset before programming.
