### PR TITLE
Completely ignore RISCV environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-RISCV ?= $(CURDIR)/toolchain
-PATH := $(RISCV)/bin:$(PATH)
-
 srcdir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 srcdir := $(srcdir:/=)
 wrkdir := $(CURDIR)/work
@@ -43,6 +40,7 @@ help :
 toolchain_srcdir := $(srcdir)/riscv-gnu-toolchain
 toolchain32_wrkdir := $(wrkdir)/riscv32-gnu-toolchain
 toolchain_dest := $(CURDIR)/toolchain
+PATH := $(toolchain_dest)/bin:$(PATH)
 
 openocd_srcdir := $(srcdir)/openocd
 openocd_wrkdir := $(wrkdir)/openocd


### PR DESCRIPTION
This Makefile installs the tools in a fixed location and ignores $RISCV, so $RISCV should not be used to set $PATH.  The incorrect $PATH setting prevents the compiler from building, as it can't find the assembler.