### PR TITLE
Use HTTPS when ever possible and speedup the first build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "openocd"]
 	path = openocd
-	url = http://github.com/sifive/openocd.git
+	url = https://github.com/sifive/openocd.git
 [submodule "riscv-gnu-toolchain"]
 	path = riscv-gnu-toolchain
-	url = http://github.com/riscv/riscv-gnu-toolchain.git
+	url = https://github.com/riscv/riscv-gnu-toolchain.git

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository, maintained by SiFive, Inc, makes it easy to get started develop
 First, clone this repository:
 
 ```
-git clone --recursive http://github.com/sifive/freedom-e-sdk.git
+git clone --recursive https://github.com/sifive/freedom-e-sdk.git
 ```
 
 Ubuntu packages needed:
@@ -25,7 +25,7 @@ Next, build the tools:
 
 ```
 cd freedom-e-sdk
-make tools
+make -j $(nproc) tools
 ```
 
 To compile a bare-metal RISC-V program:
@@ -93,4 +93,4 @@ to download and run the benchmark on the HiFive1 board:
 
 Documentation, Forums, and much more available at
 
-[dev.sifive.com](http://dev.sifive.com)
+[dev.sifive.com](https://dev.sifive.com)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Next, build the tools:
 
 ```
 cd freedom-e-sdk
-make -j $(nproc) tools
+make tools
 ```
+
+Provided you have your machine has enough resources you can speed up the build process by adding `-j n` to make where `n` is the amount of processors of your build system.
 
 To compile a bare-metal RISC-V program:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd freedom-e-sdk
 make tools
 ```
 
-Provided you have your machine has enough resources you can speed up the build process by adding `-j n` to make where `n` is the amount of processors of your build system.
+If your machine has enough resources, you can speed up the build process by adding `-j n` to `make`, where `n` is the number of processors of your build system.
 
 To compile a bare-metal RISC-V program:
 


### PR DESCRIPTION
Hi all

I noticed that the readme used http for most links.
While cloning the repo, I noticed most of the submodules are http too. Since github redirects to https anyways I updated the module path.

Regards