### PR TITLE
E300 Arty: Don't specify the expected ID

### DIFF
--- a/bsp/env/freedom-e300-arty/openocd.cfg
+++ b/bsp/env/freedom-e300-arty/openocd.cfg
@@ -13,13 +13,13 @@ ftdi_layout_signal LED -data 0x0800
 #
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 5
 
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 $_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
 
-flash bank my_first_flash fespi 0x20000000 0 0 0 $_TARGETNAME
+flash bank my_first_flash fespi 0x20000000 0 0 0 $_TARGETNAME 0x10014000
 init
 #reset
 if {[ info exists pulse_srst]} {


### PR DESCRIPTION
The expected ID was really only used to determine where the SPIFlash controller was. Since this is brittle and requires hard-coding a lot of IDs inside OpenOCD binary, instead we have the user specify the SPIFlash controller address on the `flash bank` command. 

This fix will allow this BSP to be used for the latest version built from https://github.com/sifive/freedom, where the IDCODE is different. OpenOCD is able to determine how to interact with either version by itself without the IDCODE.