### PR TITLE
Add _FUNC aliases for newlib-2.5.0

### DIFF
--- a/bsp/libwrap/libwrap.mk
+++ b/bsp/libwrap/libwrap.mk
@@ -42,6 +42,7 @@ LIBWRAP := libwrap.a
 LINK_DEPS += $(LIBWRAP)
 
 LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=$(s))
+LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=_$(s))
 LDFLAGS += -L. -Wl,--start-group -lwrap -lc -Wl,--end-group
 
 CLEAN_OBJS += $(LIBWRAP_OBJS)

--- a/bsp/libwrap/sys/_exit.c
+++ b/bsp/libwrap/sys/_exit.c
@@ -2,8 +2,9 @@
 
 #include <unistd.h>
 #include "platform.h"
+#include "weak_under_alias.h"
 
-void __wrap__exit(int code)
+void __wrap_exit(int code)
 {
   const char message[] = "\nProgam has exited with code:";
 
@@ -13,3 +14,4 @@ void __wrap__exit(int code)
 
   for (;;);
 }
+weak_under_alias(exit);

--- a/bsp/libwrap/sys/close.c
+++ b/bsp/libwrap/sys/close.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_close(int fd)
 {
   return _stub(EBADF);
 }
+weak_under_alias(close);

--- a/bsp/libwrap/sys/execve.c
+++ b/bsp/libwrap/sys/execve.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_execve(const char* name, char* const argv[], char* const env[])
 {
   return _stub(ENOMEM);
 }
+weak_under_alias(execve);

--- a/bsp/libwrap/sys/fstat.c
+++ b/bsp/libwrap/sys/fstat.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_fstat(int fd, struct stat* st)
 {
@@ -14,3 +15,4 @@ int __wrap_fstat(int fd, struct stat* st)
 
   return _stub(EBADF);
 }
+weak_under_alias(fstat);

--- a/bsp/libwrap/sys/getpid.c
+++ b/bsp/libwrap/sys/getpid.c
@@ -1,6 +1,8 @@
 /* See LICENSE of license details. */
+#include "weak_under_alias.h"
 
 int __wrap_getpid(void)
 {
   return 1;
 }
+weak_under_alias(getpid);

--- a/bsp/libwrap/sys/isatty.c
+++ b/bsp/libwrap/sys/isatty.c
@@ -1,6 +1,7 @@
 /* See LICENSE of license details. */
 
 #include <unistd.h>
+#include "weak_under_alias.h"
 
 int __wrap_isatty(int fd)
 {
@@ -9,3 +10,4 @@ int __wrap_isatty(int fd)
 
   return 0;
 }
+weak_under_alias(isatty);

--- a/bsp/libwrap/sys/kill.c
+++ b/bsp/libwrap/sys/kill.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_kill(int pid, int sig)
 {
   return _stub(EINVAL);
 }
+weak_under_alias(kill);

--- a/bsp/libwrap/sys/link.c
+++ b/bsp/libwrap/sys/link.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_link(const char *old_name, const char *new_name)
 {
   return _stub(EMLINK);
 }
+weak_under_alias(link);

--- a/bsp/libwrap/sys/lseek.c
+++ b/bsp/libwrap/sys/lseek.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 off_t __wrap_lseek(int fd, off_t ptr, int dir)
 {
@@ -12,3 +13,4 @@ off_t __wrap_lseek(int fd, off_t ptr, int dir)
 
   return _stub(EBADF);
 }
+weak_under_alias(lseek);

--- a/bsp/libwrap/sys/open.c
+++ b/bsp/libwrap/sys/open.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_open(const char* name, int flags, int mode)
 {
   return _stub(ENOENT);
 }
+weak_under_alias(open);

--- a/bsp/libwrap/sys/openat.c
+++ b/bsp/libwrap/sys/openat.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_openat(int dirfd, const char* name, int flags, int mode)
 {
   return _stub(ENOENT);
 }
+weak_under_alias(openat);

--- a/bsp/libwrap/sys/puts.c
+++ b/bsp/libwrap/sys/puts.c
@@ -7,6 +7,7 @@
 
 #include "platform.h"
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_puts(const char *s)
 {
@@ -24,3 +25,4 @@ int __wrap_puts(const char *s)
 
   return 0;
 }
+weak_under_alias(puts);

--- a/bsp/libwrap/sys/read.c
+++ b/bsp/libwrap/sys/read.c
@@ -7,6 +7,7 @@
 
 #include "platform.h"
 #include "stub.h"
+#include "weak_under_alias.h"
 
 ssize_t __wrap_read(int fd, void* ptr, size_t len)
 {
@@ -28,3 +29,4 @@ ssize_t __wrap_read(int fd, void* ptr, size_t len)
 
   return _stub(EBADF);
 }
+weak_under_alias(read);

--- a/bsp/libwrap/sys/sbrk.c
+++ b/bsp/libwrap/sys/sbrk.c
@@ -1,6 +1,7 @@
 /* See LICENSE of license details. */
 
 #include <stddef.h>
+#include "weak_under_alias.h"
 
 void *__wrap_sbrk(ptrdiff_t incr)
 {
@@ -14,3 +15,4 @@ void *__wrap_sbrk(ptrdiff_t incr)
   curbrk += incr;
   return curbrk - incr;
 }
+weak_under_alias(sbrk);

--- a/bsp/libwrap/sys/stat.c
+++ b/bsp/libwrap/sys/stat.c
@@ -3,8 +3,10 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_stat(const char* file, struct stat* st)
 {
   return _stub(EACCES);
 }
+weak_under_alias(stat);

--- a/bsp/libwrap/sys/times.c
+++ b/bsp/libwrap/sys/times.c
@@ -3,8 +3,10 @@
 #include <errno.h>
 #include <sys/times.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 clock_t __wrap_times(struct tms* buf)
 {
   return _stub(EACCES);
 }
+weak_under_alias(times);

--- a/bsp/libwrap/sys/unlink.c
+++ b/bsp/libwrap/sys/unlink.c
@@ -2,8 +2,10 @@
 
 #include <errno.h>
 #include "stub.h"
+#include "weak_under_alias.h"
 
 int __wrap_unlink(const char* name)
 {
   return _stub(ENOENT);
 }
+weak_under_alias(unlink);

--- a/bsp/libwrap/sys/weak_under_alias.h
+++ b/bsp/libwrap/sys/weak_under_alias.h
@@ -1,0 +1,7 @@
+#ifndef _BSP_LIBWRAP_WEAK_UNDER_ALIAS_H
+#define _BSP_LIBWRAP_WEAK_UNDER_ALIAS_H
+
+#define weak_under_alias(name) \
+  extern __typeof (__wrap_##name) __wrap__##name __attribute__ ((weak, alias ("__wrap_"#name)))
+
+#endif

--- a/bsp/libwrap/sys/write.c
+++ b/bsp/libwrap/sys/write.c
@@ -7,6 +7,7 @@
 
 #include "platform.h"
 #include "stub.h"
+#include "weak_under_alias.h"
 
 ssize_t __wrap_write(int fd, const void* ptr, size_t len)
 {
@@ -27,3 +28,4 @@ ssize_t __wrap_write(int fd, const void* ptr, size_t len)
 
   return _stub(EBADF);
 }
+weak_under_alias(write);


### PR DESCRIPTION
I'm not sure what the policy actaully is here, but some newlib functions
now have an extra underscore before them.  This defines a bunch of
aliases and some more wrappers to link against the correct newlib
functions for 2.5.0 but maintain compatibility with 2.4.0.