### PR TITLE
Fpga update

### DIFF
--- a/bsp/env/common.mk
+++ b/bsp/env/common.mk
@@ -26,6 +26,7 @@ TOOL_DIR = $(BSP_BASE)/../toolchain/bin
 
 LDFLAGS += -T $(LINKER_SCRIPT) -nostartfiles
 LDFLAGS += -L$(ENV_DIR)
+LDFLAGS += -specs=nano.specs
 
 ASM_OBJS := $(ASM_SRCS:.S=.o)
 C_OBJS := $(C_SRCS:.c=.o)

--- a/bsp/env/coreplexip-e31-arty/dhrystone.lds
+++ b/bsp/env/coreplexip-e31-arty/dhrystone.lds
@@ -5,7 +5,7 @@ ENTRY( _start )
 MEMORY
 {
   flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 512M
-  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 16K
+  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 64K
 }
 
 PHDRS

--- a/bsp/env/coreplexip-e31-arty/flash.lds
+++ b/bsp/env/coreplexip-e31-arty/flash.lds
@@ -5,7 +5,7 @@ ENTRY( _start )
 MEMORY
 {
   flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 512M
-  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 16K
+  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 64K
 }
 
 PHDRS

--- a/bsp/env/coreplexip-e31-arty/scratchpad.lds
+++ b/bsp/env/coreplexip-e31-arty/scratchpad.lds
@@ -4,7 +4,7 @@ ENTRY( _start )
 
 MEMORY
 {
-  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 16K
+  ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 64K
 }
 
 PHDRS


### PR DESCRIPTION
Update linker files for larger FPGA dtim in the v2p0 images. Also default to using newlib-nano.