### PR TITLE
bsp:devices:spi.h: fix sckmode fields value

### DIFF
--- a/bsp/include/sifive/devices/spi.h
+++ b/bsp/include/sifive/devices/spi.h
@@ -30,8 +30,8 @@
 
 /* Fields */
 
-#define SPI_SCK_POL             0x1
-#define SPI_SCK_PHA             0x2
+#define SPI_SCK_PHA             0x1
+#define SPI_SCK_POL             0x2
 
 #define SPI_FMT_PROTO(x)        ((x) & 0x3)
 #define SPI_FMT_ENDIAN(x)       (((x) & 0x1) << 2)


### PR DESCRIPTION
According to : 
- SiFive FE310-G000 Manual;
- src/main/scala/devices/spi/TLSPI.scala on github sifive-blocks
- and control with logic analyzer.
CPHA is the bit 0 of sckmod register (ie value 0 or 1) and CPOL is the bit 1 of sckmod register (ie value 0 or 2).
This patch correct values for these to define  