### PR TITLE
Use the appropriate toolchain (32 vs 64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,11 @@ toolchain_prefix := $(toolchain_builddir)/prefix
 
 RISCV_PATH ?= $(toolchain_prefix)
 
-RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-gcc)
-RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-g++)
-RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-objdump)
-RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-gdb)
-RISCV_AR      := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-ar)
+RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/riscv$(RISCV_XLEN)-unknown-elf-gcc)
+RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/riscv$(RISCV_XLEN)-unknown-elf-g++)
+RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/riscv$(RISCV_XLEN)-unknown-elf-objdump)
+RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/riscv$(RISCV_XLEN)-unknown-elf-gdb)
+RISCV_AR      := $(abspath $(RISCV_PATH)/bin/riscv$(RISCV_XLEN)-unknown-elf-ar)
 
 PATH := $(abspath $(RISCV_PATH)/bin):$(PATH)
 


### PR DESCRIPTION
I had issues using my own compiled toolchain from https://github.com/sifive/freedom dependency https://github.com/freechipsproject/rocket-chip.

Basically anyone who has followed https://github.com/freechipsproject/rocket-chip will have 2 toolchains installed, riscv32-unknown-elf- and riscv64-unknown-elf-, which will cause problems with using the wrong compiler here (and errors ELFCLASS64 vs ELFCLASS32 at linking stage), so let's just apply the right name to the toolchain.