### PR TITLE
Allow users to set a CROSS_COMPLIE argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 # Configuration
 #############################################################
 
+# Allow users to select a different cross compiler.
+CROSS_COMPILE ?= riscv64-unknown-elf
+
 # Allows users to create Makefile.local or ../Makefile.project with
 # configuration variables, so they don't have to be set on the command-line
 # every time.
@@ -96,11 +99,11 @@ toolchain_prefix := $(toolchain_builddir)/prefix
 
 RISCV_PATH ?= $(toolchain_prefix)
 
-RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-gcc)
-RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-g++)
-RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-objdump)
-RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-gdb)
-RISCV_AR      := $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-ar)
+RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-gcc)
+RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-g++)
+RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-objdump)
+RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-gdb)
+RISCV_AR      := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-ar)
 
 PATH := $(abspath $(RISCV_PATH)/bin):$(PATH)
 


### PR DESCRIPTION
This allows users to select a different cross complier than the default
'riscv64-unknown-elf'.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>