### PR TITLE
Add support for generating coreip hex files via elf2hex

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "freedom-mee"]
 	path = freedom-mee
 	url = https://github.com/sifive/freedom-mee.git
+[submodule "scripts/elf2hex"]
+	path = scripts/elf2hex
+	url = ../elf2hex

--- a/bsp/coreip-e31-arty/settings.mk
+++ b/bsp/coreip-e31-arty/settings.mk
@@ -1,4 +1,3 @@
-#write_config_file
-
 RISCV_ARCH=rv32imac
 RISCV_ABI=ilp32
+COREIP_HEX_WIDTH=32

--- a/bsp/coreip-s51-arty/settings.mk
+++ b/bsp/coreip-s51-arty/settings.mk
@@ -1,4 +1,3 @@
-#write_config_file
-
 RISCV_ARCH=rv64imac
 RISCV_ABI=lp64
+COREIP_HEX_WIDTH=32

--- a/bsp/coreip-s51/settings.mk
+++ b/bsp/coreip-s51/settings.mk
@@ -1,4 +1,3 @@
-#write_config_file
-
 RISCV_ARCH=rv64imac
 RISCV_ABI=lp64
+COREIP_MEM_WIDTH=32


### PR DESCRIPTION
This just calls elf2hex on the compiled elf files, producing a hex file
that can be fed into RTL simulation.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>