### PR TITLE
Add fixed-clocks to e31 and s51 Arty targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,8 +234,8 @@ $(PROGRAM_ELF): \
 		AR=$(RISCV_AR) \
 		CC=$(RISCV_GCC) \
 		CXX=$(RISCV_GXX) \
-		CFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g" \
-		CXXFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g" \
+		CFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g -I$(abspath $(MEE_BSP_PATH)/install/include/)" \
+		CXXFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g -I$(abspath $(MEE_BSP_PATH)/install/include/)" \
 		LDFLAGS="-nostartfiles -nostdlib -L$(sort $(dir $(abspath $(filter %.a,$^)))) -T$(abspath $(filter %.lds,$^))" \
 		LDLIBS="-Wl,--start-group -lc -lgcc -lmee -lmee-gloss -Wl,--end-group"
 	touch -c $@

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ $(MEE_BSP_PATH)/build/Makefile:
 	@rm -rf $(dir $@)
 	@mkdir -p $(dir $@)
 	cd $(dir $@) && \
-		CFLAGS="-march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g" \
+		CFLAGS="-march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g -mcmodel=medany" \
 		$(abspath $(MEE_SOURCE_PATH)/configure) \
 		--host=$(CROSS_COMPILE) \
 		--prefix=$(abspath $(MEE_BSP_PATH)/install) \
@@ -234,8 +234,8 @@ $(PROGRAM_ELF): \
 		AR=$(RISCV_AR) \
 		CC=$(RISCV_GCC) \
 		CXX=$(RISCV_GXX) \
-		CFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g -I$(abspath $(MEE_BSP_PATH)/install/include/)" \
-		CXXFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g -I$(abspath $(MEE_BSP_PATH)/install/include/)" \
+		CFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -mcmodel=medany -g -I$(abspath $(MEE_BSP_PATH)/install/include/)" \
+		CXXFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g -mcmodel=medany -I$(abspath $(MEE_BSP_PATH)/install/include/)" \
 		LDFLAGS="-nostartfiles -nostdlib -L$(sort $(dir $(abspath $(filter %.a,$^)))) -T$(abspath $(filter %.lds,$^))" \
 		LDLIBS="-Wl,--start-group -lc -lgcc -lmee -lmee-gloss -Wl,--end-group"
 	touch -c $@

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ $(PROGRAM_ELF): \
 		CFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g" \
 		CXXFLAGS="-Os -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -g" \
 		LDFLAGS="-nostartfiles -nostdlib -L$(sort $(dir $(abspath $(filter %.a,$^)))) -T$(abspath $(filter %.lds,$^))" \
-		LDLIBS="-Wl,--start-group -lc -lmee -lmee-gloss -Wl,--end-group"
+		LDLIBS="-Wl,--start-group -lc -lgcc -lmee -lmee-gloss -Wl,--end-group"
 	touch -c $@
 
 $(PROGRAM_HEX): \

--- a/bsp/coreip-e31-arty/design.dts
+++ b/bsp/coreip-e31-arty/design.dts
@@ -40,6 +40,11 @@
 		#size-cells = <1>;
 		compatible = "SiFive,FE310G-soc", "fe310-soc", "sifive-soc", "simple-bus";
 		ranges;
+		hfclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32500000>;
+		};
 		L1: clint@2000000 {
 			compatible = "riscv,clint0";
 			interrupts-extended = <&L3 3 &L3 7>;
@@ -105,6 +110,7 @@
 			interrupts = <5>;
 			reg = <0x20000000 0x1000>;
 			reg-names = "control";
+			clocks = <&hfclk>;
 		};
 		L12: spi@20004000 {
 			compatible = "sifive,spi0";

--- a/bsp/coreip-e31-arty/mee.h
+++ b/bsp/coreip-e31-arty/mee.h
@@ -1,7 +1,12 @@
 #ifndef ASSEMBLY
+#include <mee/drivers/fixed-clock.h>
 #include <mee/drivers/sifive,gpio0.h>
 #include <mee/drivers/sifive,uart0.h>
 #include <mee/drivers/sifive,test0.h>
+/* From clock@0 */
+asm (".weak __mee_dt_clock_0");
+struct __mee_driver_fixed_clock __mee_dt_clock_0;
+
 /* From gpio@20002000 */
 asm (".weak __mee_dt_gpio_20002000");
 struct __mee_driver_sifive_gpio0 __mee_dt_gpio_20002000;
@@ -13,6 +18,13 @@ struct __mee_driver_sifive_uart0 __mee_dt_serial_20000000;
 /* From teststatus@4000 */
 asm (".weak __mee_dt_teststatus_4000");
 struct __mee_driver_sifive_test0 __mee_dt_teststatus_4000;
+
+/* From clock@0 */
+struct __mee_driver_fixed_clock __mee_dt_clock_0 = {
+    .vtable = &__mee_driver_vtable_fixed_clock,
+    .clock.vtable = &__mee_driver_vtable_fixed_clock.clock,
+    .rate = 32500000UL,
+};
 
 /* From gpio@20002000 */
 struct __mee_driver_sifive_gpio0 __mee_dt_gpio_20002000 = {
@@ -27,7 +39,8 @@ struct __mee_driver_sifive_uart0 __mee_dt_serial_20000000 = {
     .uart.vtable = &__mee_driver_vtable_sifive_uart0.uart,
     .control_base = 536870912UL,
     .control_size = 4096UL,
-    .clock = NULL,
+/* From clock@0 */
+    .clock = &__mee_dt_clock_0.clock,
     .pinmux = NULL,
 };
 

--- a/bsp/coreip-s51-arty/design.dts
+++ b/bsp/coreip-s51-arty/design.dts
@@ -40,6 +40,11 @@
 		#size-cells = <1>;
 		compatible = "SiFive,FE510G-soc", "fe510-soc", "sifive-soc", "simple-bus";
 		ranges;
+		hfclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32500000>;
+		};
 		L1: clint@2000000 {
 			compatible = "riscv,clint0";
 			interrupts-extended = <&L3 3 &L3 7>;
@@ -105,6 +110,7 @@
 			interrupts = <5>;
 			reg = <0x20000000 0x1000>;
 			reg-names = "control";
+			clocks = <&hfclk>;
 		};
 		L12: spi@20004000 {
 			compatible = "sifive,spi0";

--- a/bsp/coreip-s51-arty/mee.h
+++ b/bsp/coreip-s51-arty/mee.h
@@ -1,7 +1,12 @@
 #ifndef ASSEMBLY
+#include <mee/drivers/fixed-clock.h>
 #include <mee/drivers/sifive,gpio0.h>
 #include <mee/drivers/sifive,uart0.h>
 #include <mee/drivers/sifive,test0.h>
+/* From clock@0 */
+asm (".weak __mee_dt_clock_0");
+struct __mee_driver_fixed_clock __mee_dt_clock_0;
+
 /* From gpio@20002000 */
 asm (".weak __mee_dt_gpio_20002000");
 struct __mee_driver_sifive_gpio0 __mee_dt_gpio_20002000;
@@ -13,6 +18,13 @@ struct __mee_driver_sifive_uart0 __mee_dt_serial_20000000;
 /* From teststatus@4000 */
 asm (".weak __mee_dt_teststatus_4000");
 struct __mee_driver_sifive_test0 __mee_dt_teststatus_4000;
+
+/* From clock@0 */
+struct __mee_driver_fixed_clock __mee_dt_clock_0 = {
+    .vtable = &__mee_driver_vtable_fixed_clock,
+    .clock.vtable = &__mee_driver_vtable_fixed_clock.clock,
+    .rate = 32500000UL,
+};
 
 /* From gpio@20002000 */
 struct __mee_driver_sifive_gpio0 __mee_dt_gpio_20002000 = {
@@ -27,7 +39,8 @@ struct __mee_driver_sifive_uart0 __mee_dt_serial_20000000 = {
     .uart.vtable = &__mee_driver_vtable_sifive_uart0.uart,
     .control_base = 536870912UL,
     .control_size = 4096UL,
-    .clock = NULL,
+/* From clock@0 */
+    .clock = &__mee_dt_clock_0.clock,
     .pinmux = NULL,
 };
 


### PR DESCRIPTION
This properly initializes the serial devices on the Arty evaluation targets so that the serial terminal output works.

Merge after #126 