### PR TITLE
Fix OpenOCD path in Makefile and Add Configurations for Arty Boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,15 +131,19 @@ RISCV_GXX     := $(CROSS_COMPILE)-g++
 RISCV_OBJDUMP := $(CROSS_COMPILE)-objdump
 RISCV_GDB     := $(CROSS_COMPILE)-gdb
 RISCV_AR      := $(CROSS_COMPILE)-ar
-RISCV_OPENOCD := openocd
 else
 RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-gcc)
 RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-g++)
 RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-objdump)
 RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-gdb)
 RISCV_AR      := $(abspath $(RISCV_PATH)/bin/$(CROSS_COMPILE)-ar)
-RISCV_OPENOCD := $(abspath $(RISCV_PATH)/bin/openocd)
 PATH          := $(abspath $(RISCV_PATH)/bin):$(PATH)
+endif
+
+ifeq ($(RISCV_OPENOCD_PATH),)
+RISCV_OPENOCD := openocd
+else
+RISCV_OPENOCD := $(abspath $(RISCV_OPENOCD_PATH)/bin/openocd)
 endif
 
 #############################################################

--- a/bsp/coreip-e31-arty/openocd.cfg
+++ b/bsp/coreip-e31-arty/openocd.cfg
@@ -1,0 +1,30 @@
+adapter_khz     10000
+
+#source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]
+
+interface ftdi
+ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
+ftdi_vid_pid 0x15ba 0x002a
+
+ftdi_layout_init 0x0808 0x0a1b
+ftdi_layout_signal nSRST -oe 0x0200
+ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
+ftdi_layout_signal LED -data 0x0800
+#
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
+
+flash bank my_first_flash fespi 0x40000000 0 0 0 $_TARGETNAME 0x20004000
+init
+#reset
+if {[ info exists pulse_srst]} {
+  ftdi_set_signal nSRST 0
+  ftdi_set_signal nSRST z
+}
+halt
+#flash protect 0 64 last off

--- a/bsp/coreip-s51-arty/openocd.cfg
+++ b/bsp/coreip-s51-arty/openocd.cfg
@@ -1,0 +1,30 @@
+adapter_khz     10000
+
+#source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]
+
+interface ftdi
+ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
+ftdi_vid_pid 0x15ba 0x002a
+
+ftdi_layout_init 0x0808 0x0a1b
+ftdi_layout_signal nSRST -oe 0x0200
+ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
+ftdi_layout_signal LED -data 0x0800
+#
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
+
+flash bank my_first_flash fespi 0x40000000 0 0 0 $_TARGETNAME 0x20004000
+init
+#reset
+if {[ info exists pulse_srst]} {
+  ftdi_set_signal nSRST 0
+  ftdi_set_signal nSRST z
+}
+halt
+#flash protect 0 64 last off

--- a/bsp/freedom-e310-arty/openocd.cfg
+++ b/bsp/freedom-e310-arty/openocd.cfg
@@ -1,0 +1,30 @@
+adapter_khz     10000
+
+#source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]
+
+interface ftdi
+ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
+ftdi_vid_pid 0x15ba 0x002a
+
+ftdi_layout_init 0x0808 0x0a1b
+ftdi_layout_signal nSRST -oe 0x0200
+ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
+ftdi_layout_signal LED -data 0x0800
+#
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
+
+flash bank my_first_flash fespi 0x20000000 0 0 0 $_TARGETNAME 0x10014000
+init
+#reset
+if {[ info exists pulse_srst]} {
+  ftdi_set_signal nSRST 0
+  ftdi_set_signal nSRST z
+}
+halt
+#flash protect 0 64 last off


### PR DESCRIPTION
Update the Makefile to look for OpenOCD in RISCV_OPENOCD_PATH.

Add OpenOCD configurations to the Arty boards.