### PR TITLE
Disable maintainer mode in MEE build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ $(BSP_DIR)/build/Makefile:
 		$(abspath $(MEE_SOURCE_PATH)/configure) \
 		--host=$(CROSS_COMPILE) \
 		--prefix=$(abspath $(BSP_DIR)/install) \
+		--disable-maintainer-mode \
 		--with-preconfigured \
 		--with-machine-name=$(BOARD) \
 		--with-machine-header=$(abspath $(MEE_HEADER)) \


### PR DESCRIPTION
To support users without automake/autoconf/m4, disable maintainer mode
during the Freedom Metal build to make sure that the autoconf scripts
don't try to run automatically.