### PR TITLE
List options target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,15 +108,27 @@ clean:
 
 ifeq ($(BSP),mee)
 
-# MEE boards are any folders that aren't the Legacy BSP or update-targets.sh
 EXCLUDE_BOARD_DIRS = drivers env include libwrap update-targets.sh
+
+# MEE boards are any folders that aren't the Legacy BSP or update-targets.sh
 list-boards:
-	@echo $(sort $(filter-out $(EXCLUDE_BOARD_DIRS),$(notdir $(wildcard bsp/*))))
+	@echo bsp-list: $(sort $(filter-out $(EXCLUDE_BOARD_DIRS),$(notdir $(wildcard bsp/*))))
 
 
 # MEE programs are any submodules in the software folder
 list-programs:
-	@echo $(shell grep -o '= software/.*$$' .gitmodules | sed -r 's/.*\///')
+	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed -r 's/.*\///')
+
+
+# List all available MEE boards and programs in a form that Freedom Studio 
+# knows how to parse.  Do not change the format or fixed text of the output
+# without consulting the Freedom Studio dev team.
+# MEE programs are any submodules in the software folder
+# MEE boards are any folders that aren't the Legacy BSP or update-targets.sh
+list-options:
+	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed -r 's/.*\///')
+	@echo bsp-list: $(sort $(filter-out $(EXCLUDE_BOARD_DIRS),$(notdir $(wildcard bsp/*))))
+	@echo done
 
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,9 @@ clean:
 # Freedom Studio dev team.
 #############################################################
 ifeq ($(BSP),mee)
-EXCLUDE_BOARD_DIRS = drivers env include libwrap update-targets.sh
 
 # MEE boards are any folders that aren't the Legacy BSP or update-targets.sh
+EXCLUDE_BOARD_DIRS = drivers env include libwrap update-targets.sh
 list-boards:
 	@echo bsp-list: $(sort $(filter-out $(EXCLUDE_BOARD_DIRS),$(notdir $(wildcard bsp/*))))
 

--- a/Makefile
+++ b/Makefile
@@ -104,30 +104,24 @@ clean:
 
 #############################################################
 # Enumerate MEE BSPs and Programs
+#
+# List all available MEE boards and programs in a form that 
+# Freedom Studio knows how to parse.  Do not change the 
+# format or fixed text of the output without consulting the 
+# Freedom Studio dev team.
 #############################################################
-
 ifeq ($(BSP),mee)
-
 EXCLUDE_BOARD_DIRS = drivers env include libwrap update-targets.sh
 
 # MEE boards are any folders that aren't the Legacy BSP or update-targets.sh
 list-boards:
 	@echo bsp-list: $(sort $(filter-out $(EXCLUDE_BOARD_DIRS),$(notdir $(wildcard bsp/*))))
 
-
 # MEE programs are any submodules in the software folder
 list-programs:
 	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed -r 's/.*\///')
 
-
-# List all available MEE boards and programs in a form that Freedom Studio 
-# knows how to parse.  Do not change the format or fixed text of the output
-# without consulting the Freedom Studio dev team.
-# MEE programs are any submodules in the software folder
-# MEE boards are any folders that aren't the Legacy BSP or update-targets.sh
-list-options:
-	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed -r 's/.*\///')
-	@echo bsp-list: $(sort $(filter-out $(EXCLUDE_BOARD_DIRS),$(notdir $(wildcard bsp/*))))
+list-options: list-programs list-boards
 	@echo done
 
 endif


### PR DESCRIPTION
I changed the `Makefile` to 

1. Add a `list-options` target that Freedom Studio uses to get the boards and program in a single `make` call.  It also adds a "done" terminator to the end of the recipe that FS waits for to know the output is complete.  
1. Added leaders to the `list-boards` and `list-programs` targets to aid in parsing
1. More comments to ward people off from changing the target recipe

The output now looks like:

```
program-list: hello example-itim software-interrupt timer-interrupt local-interrupt return-fail return-pass
bsp-list: coreip-e31 coreip-e31-arty coreip-s51 coreip-s51-arty freedom-e310-arty sifive-hifive1
done
```

