### PR TITLE
Fix list-programs on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,9 @@ list-boards:
 
 # MEE programs are any submodules in the software folder
 list-programs:
-	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed -r 's/.*\///')
+	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed 's/.*\///')
 
 list-options: list-programs list-boards
-	@echo done
 
 endif
 


### PR DESCRIPTION
Remove '-r' from sed command (not required and does not work on MacOS).  Tested on Linux/Msys/MacOS.
Remove 'echo Done', no longer needed. I found a better way.