### PR TITLE
Fix github-linguist language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Fix github-linguist detection of language usage
+
+*.c linguist-language=C
+*.h linguist-language=C
+


### PR DESCRIPTION
If at some point it matters what language stats are displayed, this tells `github-linguist` to detect all .h and .c files as C instead of C++ or Objective-C.