### PR TITLE
Update Metal with GPIO and Cache APIs

### DIFF
--- a/bsp/coreip-e20-arty/design.dts
+++ b/bsp/coreip-e20-arty/design.dts
@@ -7,7 +7,7 @@
 	model = "SiFive,FE200G";
         chosen {
                 stdout-path = "/soc/serial@20000000:115200";
-                mee,entry = <&L6 0x400000>;
+                metal,entry = <&L6 0x400000>;
         };
 	L15: aliases {
 		serial0 = &L5;

--- a/bsp/coreip-e20-arty/metal.h
+++ b/bsp/coreip-e20-arty/metal.h
@@ -239,6 +239,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@2000000 */
@@ -463,6 +464,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-e20-arty/metal.lds
+++ b/bsp/coreip-e20-arty/metal.lds
@@ -5,7 +5,7 @@ ENTRY(_enter)
 MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-e20/metal.h
+++ b/bsp/coreip-e20/metal.h
@@ -173,6 +173,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_LOCAL_EXTERNAL_INTERRUPTS_0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-e21-arty/design.dts
+++ b/bsp/coreip-e21-arty/design.dts
@@ -7,7 +7,7 @@
 	model = "SiFive,FE210G";
         chosen {
                 stdout-path = "/soc/serial@20000000:115200";
-                mee,entry = <&L7 0x400000>;
+                metal,entry = <&L7 0x400000>;
         };
 	L17: aliases {
 		serial0 = &L6;

--- a/bsp/coreip-e21-arty/metal.h
+++ b/bsp/coreip-e21-arty/metal.h
@@ -334,6 +334,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@2000000 */
@@ -558,6 +559,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-e21-arty/metal.lds
+++ b/bsp/coreip-e21-arty/metal.lds
@@ -5,7 +5,7 @@ ENTRY(_enter)
 MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-e21/metal.h
+++ b/bsp/coreip-e21/metal.h
@@ -279,6 +279,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_LOCAL_EXTERNAL_INTERRUPTS_0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-e24-arty/design.dts
+++ b/bsp/coreip-e24-arty/design.dts
@@ -7,7 +7,7 @@
 	model = "SiFive,FE240G";
         chosen {
                 stdout-path = "/soc/serial@20000000:115200";
-                mee,entry = <&L7 0x400000>;
+                metal,entry = <&L7 0x400000>;
         };
 	L17: aliases {
 		serial0 = &L6;

--- a/bsp/coreip-e24-arty/metal.h
+++ b/bsp/coreip-e24-arty/metal.h
@@ -334,6 +334,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@2000000 */
@@ -558,6 +559,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-e24-arty/metal.lds
+++ b/bsp/coreip-e24-arty/metal.lds
@@ -5,7 +5,7 @@ ENTRY(_enter)
 MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-e24/metal.h
+++ b/bsp/coreip-e24/metal.h
@@ -279,6 +279,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_LOCAL_EXTERNAL_INTERRUPTS_0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-e31-arty/metal.h
+++ b/bsp/coreip-e31-arty/metal.h
@@ -244,6 +244,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -476,6 +477,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-e31-arty/metal.lds
+++ b/bsp/coreip-e31-arty/metal.lds
@@ -6,7 +6,7 @@ MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
 	itim (wx!rai) : ORIGIN = 0x8000000, LENGTH = 0x4000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-e31/metal.h
+++ b/bsp/coreip-e31/metal.h
@@ -335,6 +335,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-e34-arty/metal.h
+++ b/bsp/coreip-e34-arty/metal.h
@@ -244,6 +244,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -476,6 +477,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-e34-arty/metal.lds
+++ b/bsp/coreip-e34-arty/metal.lds
@@ -6,7 +6,7 @@ MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
 	itim (wx!rai) : ORIGIN = 0x8000000, LENGTH = 0x4000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-e34/metal.h
+++ b/bsp/coreip-e34/metal.h
@@ -335,6 +335,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-e76-arty/metal.h
+++ b/bsp/coreip-e76-arty/metal.h
@@ -209,6 +209,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@10060000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10060000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 268828672UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -223,6 +224,7 @@ struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10060000 = {
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -448,6 +450,13 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 2
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_10060000,
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-e76-arty/metal.lds
+++ b/bsp/coreip-e76-arty/metal.lds
@@ -5,7 +5,7 @@ ENTRY(_enter)
 MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-e76/metal.h
+++ b/bsp/coreip-e76/metal.h
@@ -286,6 +286,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-s51-arty/metal.h
+++ b/bsp/coreip-s51-arty/metal.h
@@ -244,6 +244,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -476,6 +477,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-s51-arty/metal.lds
+++ b/bsp/coreip-s51-arty/metal.lds
@@ -6,7 +6,7 @@ MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
 	itim (wx!rai) : ORIGIN = 0x8000000, LENGTH = 0x4000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-s51/metal.h
+++ b/bsp/coreip-s51/metal.h
@@ -335,6 +335,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-s54-arty/metal.h
+++ b/bsp/coreip-s54-arty/metal.h
@@ -244,6 +244,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -476,6 +477,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-s54-arty/metal.lds
+++ b/bsp/coreip-s54-arty/metal.lds
@@ -6,7 +6,7 @@ MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000
 	itim (wx!rai) : ORIGIN = 0x8000000, LENGTH = 0x4000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-s54/metal.h
+++ b/bsp/coreip-s54/metal.h
@@ -335,6 +335,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/coreip-s76-arty/metal.h
+++ b/bsp/coreip-s76-arty/metal.h
@@ -209,6 +209,7 @@ struct __metal_driver_sifive_global_external_interrupts0 __metal_dt_global_exter
 /* From gpio@10060000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10060000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 268828672UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -223,6 +224,7 @@ struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10060000 = {
 /* From gpio@20002000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_20002000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 536879104UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -448,6 +450,13 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_GLOBAL_EXINTR0_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
+
+#define __MEE_DT_MAX_GPIOS 2
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_10060000,
+					&__metal_dt_gpio_20002000};
 
 #define __METAL_DT_MAX_BUTTONS 4
 

--- a/bsp/coreip-s76-arty/metal.lds
+++ b/bsp/coreip-s76-arty/metal.lds
@@ -5,7 +5,7 @@ ENTRY(_enter)
 MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x10000000
-	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x40400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/coreip-s76/metal.h
+++ b/bsp/coreip-s76/metal.h
@@ -286,6 +286,11 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 
 #define __METAL_DT_GLOBAL_EXTERNAL_INTERRUPTS_HANDLE (&__metal_dt_global_external_interrupts.irc)
 
+#define __MEE_DT_MAX_GPIOS 0
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					NULL };
 #define __METAL_DT_MAX_BUTTONS 0
 
 asm (".weak __metal_button_table");

--- a/bsp/freedom-e310-arty/metal.h
+++ b/bsp/freedom-e310-arty/metal.h
@@ -163,6 +163,7 @@ struct __metal_driver_sifive_local_external_interrupts0 __metal_dt_local_externa
 /* From gpio@10012000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10012000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 268509184UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -252,6 +253,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
 
 #define __METAL_DT_LOCAL_EXTERNAL_INTERRUPTS_0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_10012000};
 
 #define __METAL_DT_MAX_BUTTONS 0
 

--- a/bsp/freedom-e310-arty/metal.lds
+++ b/bsp/freedom-e310-arty/metal.lds
@@ -6,7 +6,7 @@ MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x4000
 	itim (wx!rai) : ORIGIN = 0x8000000, LENGTH = 0x4000
-	flash (rxai!w) : ORIGIN = 0x20400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x20400000, LENGTH = 0x1fc00000
 }
 
 PHDRS

--- a/bsp/sifive-hifive1-revb/metal.h
+++ b/bsp/sifive-hifive1-revb/metal.h
@@ -213,6 +213,7 @@ struct __metal_driver_sifive_local_external_interrupts0 __metal_dt_local_externa
 /* From gpio@10012000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10012000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 268509184UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -355,6 +356,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
 
 #define __METAL_DT_LOCAL_EXTERNAL_INTERRUPTS_0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_10012000};
 
 #define __METAL_DT_MAX_BUTTONS 0
 

--- a/bsp/sifive-hifive1/metal.h
+++ b/bsp/sifive-hifive1/metal.h
@@ -205,6 +205,7 @@ struct __metal_driver_sifive_local_external_interrupts0 __metal_dt_local_externa
 /* From gpio@10012000 */
 struct __metal_driver_sifive_gpio0 __metal_dt_gpio_10012000 = {
     .vtable = &__metal_driver_vtable_sifive_gpio0,
+    .gpio.vtable = &__metal_driver_vtable_sifive_gpio0.gpio,
     .base = 268509184UL,
     .size = 4096UL,
 /* From interrupt_controller@c000000 */
@@ -344,6 +345,12 @@ struct __metal_driver_cpu *__metal_cpu_table[] = {
 #define __METAL_DT_SIFIVE_LOCAL_EXINTR0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
 
 #define __METAL_DT_LOCAL_EXTERNAL_INTERRUPTS_0_HANDLE (&__metal_dt_local_external_interrupts_0.irc)
+
+#define __MEE_DT_MAX_GPIOS 1
+
+asm (".weak __metal_gpio_table");
+struct __metal_driver_sifive_gpio0 *__metal_gpio_table[] = {
+					&__metal_dt_gpio_10012000};
 
 #define __METAL_DT_MAX_BUTTONS 0
 

--- a/bsp/sifive-hifive1/metal.lds
+++ b/bsp/sifive-hifive1/metal.lds
@@ -5,7 +5,7 @@ ENTRY(_enter)
 MEMORY
 {
 	ram (wxa!ri) : ORIGIN = 0x80000000, LENGTH = 0x4000
-	flash (rxai!w) : ORIGIN = 0x20400000, LENGTH = 0x20000000
+	flash (rxai!w) : ORIGIN = 0x20400000, LENGTH = 0x1fc00000
 }
 
 PHDRS


### PR DESCRIPTION
Update to the latest Metal library which includes public APIs for GPIO output and cache controllers.