### PR TITLE
Added .map + .lst + .rtl extra output files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ SRC_DIR = $(PROGRAM_ROOT)/software/$(PROGRAM)
 
 PROGRAM_ELF = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).elf
 PROGRAM_HEX = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).hex
+PROGRAM_LST = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).lst
+PROGRAM_RTL = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).rtl
 
 #############################################################
 # BSP Loading

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ SRC_DIR = $(PROGRAM_ROOT)/software/$(PROGRAM)
 PROGRAM_ELF = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).elf
 PROGRAM_HEX = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).hex
 PROGRAM_LST = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).lst
-PROGRAM_RTL = $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).rtl
 
 #############################################################
 # BSP Loading

--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -121,7 +121,6 @@ include $(CONFIGURATION).mk
 PROGRAM_ELF ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).elf
 PROGRAM_HEX ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).hex
 PROGRAM_LST ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).lst
-PROGRAM_RTL ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).rtl
 
 .PHONY: all
 all: software
@@ -129,9 +128,7 @@ all: software
 .PHONY: software
 software: $(PROGRAM_ELF)
 
-ifneq ($(filter rtl,$(TARGET_TAGS)),)
-software: $(PROGRAM_RTL)
-endif
+software: $(PROGRAM_HEX)
 
 PROGRAM_SRCS = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*.h) $(wildcard $(SRC_DIR)/*.S)
 
@@ -152,7 +149,6 @@ $(PROGRAM_ELF): \
 	mv $(SRC_DIR)/$(basename $(notdir $@)).map $(dir $@)
 	mv $(SRC_DIR)/$(basename $(notdir $@)) $@
 	touch -c $@
-	$(RISCV_OBJCOPY) -O ihex $(PROGRAM_ELF) $(PROGRAM_HEX)
 	$(RISCV_OBJDUMP) --source --all-headers --demangle --line-numbers --wide $@ > $(PROGRAM_LST)
 	$(RISCV_SIZE) $@
 
@@ -163,6 +159,10 @@ $(PROGRAM_RTL): \
 		scripts/elf2hex/install/bin/$(CROSS_COMPILE)-elf2hex \
 		$(PROGRAM_ELF)
 	$< --output $@ --input $(PROGRAM_ELF) --bit-width $(COREIP_MEM_WIDTH)
+else
+$(PROGRAM_HEX): \
+		$(PROGRAM_ELF)
+	$(RISCV_OBJCOPY) -O ihex $(PROGRAM_ELF) $@
 endif
 
 

--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -97,6 +97,8 @@ RISCV_CXXFLAGS += -I$(abspath $(BSP_DIR)/install/include/)
 
 # Turn on garbage collection for unused sections
 RISCV_LDFLAGS += -Wl,--gc-sections
+# Turn on linker map file generation
+RISCV_LDFLAGS += -Wl,-Map,$(PROGRAM).map
 # Turn off the C standard library
 RISCV_LDFLAGS += -nostartfiles -nostdlib
 # Find the archive files and linker scripts
@@ -118,6 +120,8 @@ include $(CONFIGURATION).mk
 
 PROGRAM_ELF ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).elf
 PROGRAM_HEX ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).hex
+PROGRAM_LST ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).lst
+PROGRAM_RTL ?= $(SRC_DIR)/$(CONFIGURATION)/$(PROGRAM).rtl
 
 .PHONY: all
 all: software
@@ -125,8 +129,8 @@ all: software
 .PHONY: software
 software: $(PROGRAM_ELF)
 
-ifneq ($(filter jlink rtl,$(TARGET_TAGS)),)
-software: $(PROGRAM_HEX)
+ifneq ($(filter rtl,$(TARGET_TAGS)),)
+software: $(PROGRAM_RTL)
 endif
 
 PROGRAM_SRCS = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*.h) $(wildcard $(SRC_DIR)/*.S)
@@ -145,23 +149,17 @@ $(PROGRAM_ELF): \
 		CXXFLAGS="$(RISCV_CXXFLAGS)" \
 		LDFLAGS="$(RISCV_LDFLAGS)" \
 		LDLIBS="$(RISCV_LDLIBS)"
+	mv $(SRC_DIR)/$(basename $(notdir $@)).map $(dir $@)
 	mv $(SRC_DIR)/$(basename $(notdir $@)) $@
 	touch -c $@
-
+	$(RISCV_OBJCOPY) -O ihex $(PROGRAM_ELF) $(PROGRAM_HEX)
+	$(RISCV_OBJDUMP) --source --all-headers --demangle --line-numbers --wide $@ > $(PROGRAM_LST)
 	$(RISCV_SIZE) $@
-
-# If we're using Segger J-Link OB, use objcopy to create an Intel hex file for programming
-ifneq ($(filter jlink,$(TARGET_TAGS)),)
-$(PROGRAM_HEX): \
-		$(RISCV_OBJCOPY) \
-		$(PROGRAM_ELF)
-	$< -O ihex $(PROGRAM_ELF) $@
-endif
 
 # Use elf2hex if we're creating a hex file for RTL simulation
 ifneq ($(filter rtl,$(TARGET_TAGS)),)
 .PHONY: software
-$(PROGRAM_HEX): \
+$(PROGRAM_RTL): \
 		scripts/elf2hex/install/bin/$(CROSS_COMPILE)-elf2hex \
 		$(PROGRAM_ELF)
 	$< --output $@ --input $(PROGRAM_ELF) --bit-width $(COREIP_MEM_WIDTH)

--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -155,7 +155,7 @@ $(PROGRAM_ELF): \
 # Use elf2hex if we're creating a hex file for RTL simulation
 ifneq ($(filter rtl,$(TARGET_TAGS)),)
 .PHONY: software
-$(PROGRAM_RTL): \
+$(PROGRAM_HEX): \
 		scripts/elf2hex/install/bin/$(CROSS_COMPILE)-elf2hex \
 		$(PROGRAM_ELF)
 	$< --output $@ --input $(PROGRAM_ELF) --bit-width $(COREIP_MEM_WIDTH)


### PR DESCRIPTION
In Freedom Studio 2018.12, there are more output files than just the .elf file:
- .map linker map output file
- .lst extended listing output file
- .hex flash binary output file

The .hex file is always generated in FS 2018.12, also for none JLink targets, for consistency.
FS 2018.12 is based on GNUMCU, so in order to give the user what he/she is used to with the new freedom-e-sdk, I suggest we add these new 3 files.

The RTL hex file output is renamed to have the file extension of .rtl, as the .hex file now always refers to the ihex format output file.
