### PR TITLE
Remove indirection in standalone projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ standalone: \
 	cp debug.mk $</debug.mk
 	cp release.mk $</release.mk
 
+	cp $</bsp/metal.h $</freedom-metal/metal/machine.h
+
 	echo "PROGRAM = $(PROGRAM)" > $</Makefile
 	cat scripts/standalone.mk >> $</Makefile
 	cat scripts/libmetal.mk >> $</Makefile


### PR DESCRIPTION
Copy bsp/metal.h to freedom-metal/metal/machine.h, removing the indirection that Eclipse/CDT cannot process.  I'm not advocating that this is the best solution here, but it works really well in Freedom Studio.  If there is a better way to do this feel free to "deny" PR and delete this branch.