### PR TITLE
Simplify the list-programs make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ list-target-tags:
 # Metal programs are any submodules in the software folder
 .PHONY: list-programs
 list-programs:
-	@echo program-list: $(shell grep -o '= software/.*$$' .gitmodules | sed 's/.*\///')
+	@echo program-list: $(shell ls $(PROGRAM_ROOT)/software)
 
 .PHONY: list-options
 list-options: list-programs list-targets


### PR DESCRIPTION
Just lists all the subdirectiores of PROGRAM_ROOT/software. This allows for custom examples to be added by the end-user to be visible in Freedom Studio's project wizard without having to be submodules.