### PR TITLE
DeviceTree can request a specific boot hart with 'metal,boothart' property in the chosen node

### DIFF
--- a/bsp/coreip-e20-arty/metal-inline.h
+++ b/bsp/coreip-e20-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -23,6 +23,7 @@ extern inline unsigned long __metal_driver_fixed_clock_rate(struct metal_clock *
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e20-arty/metal-platform.h
+++ b/bsp/coreip-e20-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E20_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-e20-arty/metal.default.lds
+++ b/bsp/coreip-e20-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e20-arty/metal.h
+++ b/bsp/coreip-e20-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -170,6 +170,16 @@ static inline unsigned long __metal_driver_fixed_clock_rate(struct metal_clock *
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e20-arty/metal.ramrodata.lds
+++ b/bsp/coreip-e20-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e20-arty/metal.scratchpad.lds
+++ b/bsp/coreip-e20-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e20-arty/settings.mk
+++ b/bsp/coreip-e20-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imc
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-e20-rtl/metal-inline.h
+++ b/bsp/coreip-e20-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -22,6 +22,7 @@
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e20-rtl/metal-platform.h
+++ b/bsp/coreip-e20-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E20_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-e20-rtl/metal.default.lds
+++ b/bsp/coreip-e20-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e20-rtl/metal.h
+++ b/bsp/coreip-e20-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -97,6 +97,16 @@ struct __metal_driver_sifive_test0 __metal_dt_teststatus_4000;
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e20-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-e20-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e20-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-e20-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e20-rtl/settings.mk
+++ b/bsp/coreip-e20-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medlow
 COREIP_MEM_WIDTH=32
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-e21-arty/metal-inline.h
+++ b/bsp/coreip-e21-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -23,6 +23,7 @@ extern inline unsigned long __metal_driver_fixed_clock_rate(struct metal_clock *
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e21-arty/metal-platform.h
+++ b/bsp/coreip-e21-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E21_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-e21-arty/metal.default.lds
+++ b/bsp/coreip-e21-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e21-arty/metal.h
+++ b/bsp/coreip-e21-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -174,6 +174,16 @@ static inline unsigned long __metal_driver_fixed_clock_rate(struct metal_clock *
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e21-arty/metal.ramrodata.lds
+++ b/bsp/coreip-e21-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e21-arty/metal.scratchpad.lds
+++ b/bsp/coreip-e21-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e21-arty/settings.mk
+++ b/bsp/coreip-e21-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-e21-rtl/metal-inline.h
+++ b/bsp/coreip-e21-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -22,6 +22,7 @@
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e21-rtl/metal-platform.h
+++ b/bsp/coreip-e21-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E21_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-e21-rtl/metal.default.lds
+++ b/bsp/coreip-e21-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e21-rtl/metal.h
+++ b/bsp/coreip-e21-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -103,6 +103,16 @@ struct __metal_driver_sifive_test0 __metal_dt_teststatus_4000;
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e21-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-e21-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e21-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-e21-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e21-rtl/settings.mk
+++ b/bsp/coreip-e21-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -11,3 +11,4 @@ RISCV_CMODEL=medlow
 COREIP_MEM_WIDTH=32
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-e24-arty/metal-inline.h
+++ b/bsp/coreip-e24-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -23,6 +23,7 @@ extern inline unsigned long __metal_driver_fixed_clock_rate(struct metal_clock *
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e24-arty/metal-platform.h
+++ b/bsp/coreip-e24-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E24_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-e24-arty/metal.default.lds
+++ b/bsp/coreip-e24-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e24-arty/metal.h
+++ b/bsp/coreip-e24-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -174,6 +174,16 @@ static inline unsigned long __metal_driver_fixed_clock_rate(struct metal_clock *
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e24-arty/metal.ramrodata.lds
+++ b/bsp/coreip-e24-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e24-arty/metal.scratchpad.lds
+++ b/bsp/coreip-e24-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e24-arty/settings.mk
+++ b/bsp/coreip-e24-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imafc
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32f
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-e24-rtl/metal-inline.h
+++ b/bsp/coreip-e24-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -22,6 +22,7 @@
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e24-rtl/metal-platform.h
+++ b/bsp/coreip-e24-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E24_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-e24-rtl/metal.default.lds
+++ b/bsp/coreip-e24-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e24-rtl/metal.h
+++ b/bsp/coreip-e24-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -103,6 +103,16 @@ struct __metal_driver_sifive_test0 __metal_dt_teststatus_4000;
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e24-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-e24-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e24-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-e24-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e24-rtl/settings.mk
+++ b/bsp/coreip-e24-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imafc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medlow
 COREIP_MEM_WIDTH=32
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-e31-arty/metal-inline.h
+++ b/bsp/coreip-e31-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e31-arty/metal-platform.h
+++ b/bsp/coreip-e31-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E31_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-e31-arty/metal.default.lds
+++ b/bsp/coreip-e31-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e31-arty/metal.h
+++ b/bsp/coreip-e31-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -240,6 +240,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e31-arty/metal.ramrodata.lds
+++ b/bsp/coreip-e31-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e31-arty/metal.scratchpad.lds
+++ b/bsp/coreip-e31-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e31-arty/settings.mk
+++ b/bsp/coreip-e31-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-e31-rtl/metal-inline.h
+++ b/bsp/coreip-e31-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e31-rtl/metal-platform.h
+++ b/bsp/coreip-e31-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E31_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-e31-rtl/metal.default.lds
+++ b/bsp/coreip-e31-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e31-rtl/metal.h
+++ b/bsp/coreip-e31-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -175,6 +175,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e31-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-e31-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e31-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-e31-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e31-rtl/settings.mk
+++ b/bsp/coreip-e31-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -11,3 +11,4 @@ RISCV_CMODEL=medlow
 COREIP_MEM_WIDTH=32
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-e34-arty/metal-inline.h
+++ b/bsp/coreip-e34-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e34-arty/metal-platform.h
+++ b/bsp/coreip-e34-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E34_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-e34-arty/metal.default.lds
+++ b/bsp/coreip-e34-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e34-arty/metal.h
+++ b/bsp/coreip-e34-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -240,6 +240,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e34-arty/metal.ramrodata.lds
+++ b/bsp/coreip-e34-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e34-arty/metal.scratchpad.lds
+++ b/bsp/coreip-e34-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e34-arty/settings.mk
+++ b/bsp/coreip-e34-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imafc
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32f
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-e34-rtl/metal-inline.h
+++ b/bsp/coreip-e34-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e34-rtl/metal-platform.h
+++ b/bsp/coreip-e34-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E34_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-e34-rtl/metal.default.lds
+++ b/bsp/coreip-e34-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e34-rtl/metal.h
+++ b/bsp/coreip-e34-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -175,6 +175,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e34-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-e34-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e34-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-e34-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e34-rtl/settings.mk
+++ b/bsp/coreip-e34-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imafc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medlow
 COREIP_MEM_WIDTH=32
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-e76-arty/metal-inline.h
+++ b/bsp/coreip-e76-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e76-arty/metal-platform.h
+++ b/bsp/coreip-e76-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E76_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-e76-arty/metal.default.lds
+++ b/bsp/coreip-e76-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e76-arty/metal.h
+++ b/bsp/coreip-e76-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -237,6 +237,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e76-arty/metal.ramrodata.lds
+++ b/bsp/coreip-e76-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e76-arty/metal.scratchpad.lds
+++ b/bsp/coreip-e76-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e76-arty/settings.mk
+++ b/bsp/coreip-e76-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imafc
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32f
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-e76-rtl/metal-inline.h
+++ b/bsp/coreip-e76-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-e76-rtl/metal-platform.h
+++ b/bsp/coreip-e76-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_E76_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-e76-rtl/metal.default.lds
+++ b/bsp/coreip-e76-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e76-rtl/metal.h
+++ b/bsp/coreip-e76-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -165,6 +165,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-e76-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-e76-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e76-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-e76-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-e76-rtl/settings.mk
+++ b/bsp/coreip-e76-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imafc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medlow
 COREIP_MEM_WIDTH=64
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-s51-arty/metal-inline.h
+++ b/bsp/coreip-s51-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-s51-arty/metal-platform.h
+++ b/bsp/coreip-s51-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_S51_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-s51-arty/metal.default.lds
+++ b/bsp/coreip-s51-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s51-arty/metal.h
+++ b/bsp/coreip-s51-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -240,6 +240,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-s51-arty/metal.ramrodata.lds
+++ b/bsp/coreip-s51-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s51-arty/metal.scratchpad.lds
+++ b/bsp/coreip-s51-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s51-arty/settings.mk
+++ b/bsp/coreip-s51-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imac
@@ -9,3 +9,4 @@ RISCV_ABI=lp64
 RISCV_CMODEL=medany
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-s51-rtl/metal-inline.h
+++ b/bsp/coreip-s51-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-s51-rtl/metal-platform.h
+++ b/bsp/coreip-s51-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_S51_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-s51-rtl/metal.default.lds
+++ b/bsp/coreip-s51-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s51-rtl/metal.h
+++ b/bsp/coreip-s51-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -175,6 +175,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-s51-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-s51-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s51-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-s51-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s51-rtl/settings.mk
+++ b/bsp/coreip-s51-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imac
@@ -11,3 +11,4 @@ RISCV_CMODEL=medany
 COREIP_MEM_WIDTH=64
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-s54-arty/metal-inline.h
+++ b/bsp/coreip-s54-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-s54-arty/metal-platform.h
+++ b/bsp/coreip-s54-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_S54_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-s54-arty/metal.default.lds
+++ b/bsp/coreip-s54-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s54-arty/metal.h
+++ b/bsp/coreip-s54-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -240,6 +240,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-s54-arty/metal.ramrodata.lds
+++ b/bsp/coreip-s54-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s54-arty/metal.scratchpad.lds
+++ b/bsp/coreip-s54-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s54-arty/settings.mk
+++ b/bsp/coreip-s54-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imafdc
@@ -9,3 +9,4 @@ RISCV_ABI=lp64d
 RISCV_CMODEL=medany
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-s54-rtl/metal-inline.h
+++ b/bsp/coreip-s54-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-s54-rtl/metal-platform.h
+++ b/bsp/coreip-s54-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_S54_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-s54-rtl/metal.default.lds
+++ b/bsp/coreip-s54-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s54-rtl/metal.h
+++ b/bsp/coreip-s54-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -175,6 +175,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-s54-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-s54-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s54-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-s54-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s54-rtl/settings.mk
+++ b/bsp/coreip-s54-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imafdc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medany
 COREIP_MEM_WIDTH=64
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-s76-arty/metal-inline.h
+++ b/bsp/coreip-s76-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-s76-arty/metal-platform.h
+++ b/bsp/coreip-s76-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_S76_ARTY__METAL_PLATFORM_H

--- a/bsp/coreip-s76-arty/metal.default.lds
+++ b/bsp/coreip-s76-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s76-arty/metal.h
+++ b/bsp/coreip-s76-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -237,6 +237,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-s76-arty/metal.ramrodata.lds
+++ b/bsp/coreip-s76-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s76-arty/metal.scratchpad.lds
+++ b/bsp/coreip-s76-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-34        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s76-arty/settings.mk
+++ b/bsp/coreip-s76-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-34        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imafdc
@@ -9,3 +9,4 @@ RISCV_ABI=lp64d
 RISCV_CMODEL=medany
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/coreip-s76-rtl/metal-inline.h
+++ b/bsp/coreip-s76-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-s76-rtl/metal-platform.h
+++ b/bsp/coreip-s76-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_S76_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-s76-rtl/metal.default.lds
+++ b/bsp/coreip-s76-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s76-rtl/metal.h
+++ b/bsp/coreip-s76-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -165,6 +165,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-s76-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-s76-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s76-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-s76-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -27,6 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-s76-rtl/settings.mk
+++ b/bsp/coreip-s76-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-35        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imafdc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medany
 COREIP_MEM_WIDTH=64
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-u54-rtl/metal-inline.h
+++ b/bsp/coreip-u54-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-u54-rtl/metal-platform.h
+++ b/bsp/coreip-u54-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef COREIP_U54_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-u54-rtl/metal.default.lds
+++ b/bsp/coreip-u54-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-u54-rtl/metal.h
+++ b/bsp/coreip-u54-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -171,6 +171,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-u54-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-u54-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-u54-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-u54-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/coreip-u54-rtl/settings.mk
+++ b/bsp/coreip-u54-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-35        #
+# [XXXXX] 23-05-2019 13-29-50        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imafdc
@@ -11,3 +11,4 @@ RISCV_CMODEL=medany
 COREIP_MEM_WIDTH=128
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/coreip-u54mc-rtl/design.dts
+++ b/bsp/coreip-u54mc-rtl/design.dts
@@ -5,6 +5,9 @@
 	#size-cells = <2>;
 	compatible = "SiFive,FU540G-dev", "fu540-dev", "sifive-dev";
 	model = "SiFive,FU540G";
+	chosen {
+		metal,boothart = <&L13>;
+	};
 	L36: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/bsp/coreip-u54mc-rtl/metal-inline.h
+++ b/bsp/coreip-u54mc-rtl/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -27,6 +27,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/coreip-u54mc-rtl/metal-platform.h
+++ b/bsp/coreip-u54mc-rtl/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef COREIP_U54MC_RTL__METAL_PLATFORM_H

--- a/bsp/coreip-u54mc-rtl/metal.default.lds
+++ b/bsp/coreip-u54mc-rtl/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 1);
 
 
 	.init 		:

--- a/bsp/coreip-u54mc-rtl/metal.h
+++ b/bsp/coreip-u54mc-rtl/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -249,6 +249,28 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_1) {
+		return 1;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_2) {
+		return 2;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_3) {
+		return 3;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/coreip-u54mc-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-u54mc-rtl/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 1);
 
 
 	.init 		:

--- a/bsp/coreip-u54mc-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-u54mc-rtl/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-49        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 1);
 
 
 	.init 		:

--- a/bsp/coreip-u54mc-rtl/settings.mk
+++ b/bsp/coreip-u54mc-rtl/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-35        #
+# [XXXXX] 23-05-2019 13-29-49        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv64imac
@@ -11,3 +11,4 @@ RISCV_CMODEL=medany
 COREIP_MEM_WIDTH=128
 
 TARGET_TAGS=rtl
+TARGET_DHRY_ITERS=2000

--- a/bsp/freedom-e310-arty/metal-inline.h
+++ b/bsp/freedom-e310-arty/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/freedom-e310-arty/metal-platform.h
+++ b/bsp/freedom-e310-arty/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef FREEDOM_E310_ARTY__METAL_PLATFORM_H

--- a/bsp/freedom-e310-arty/metal.default.lds
+++ b/bsp/freedom-e310-arty/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/freedom-e310-arty/metal.h
+++ b/bsp/freedom-e310-arty/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -192,6 +192,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/freedom-e310-arty/metal.ramrodata.lds
+++ b/bsp/freedom-e310-arty/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/freedom-e310-arty/metal.scratchpad.lds
+++ b/bsp/freedom-e310-arty/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/freedom-e310-arty/settings.mk
+++ b/bsp/freedom-e310-arty/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-35        #
+# [XXXXX] 23-05-2019 13-29-50        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=fpga openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/sifive-hifive-unleashed/metal-inline.h
+++ b/bsp/sifive-hifive-unleashed/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -31,6 +31,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/sifive-hifive-unleashed/metal-platform.h
+++ b/bsp/sifive-hifive-unleashed/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef SIFIVE_HIFIVE_UNLEASHED__METAL_PLATFORM_H

--- a/bsp/sifive-hifive-unleashed/metal.default.lds
+++ b/bsp/sifive-hifive-unleashed/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive-unleashed/metal.h
+++ b/bsp/sifive-hifive-unleashed/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -318,6 +318,28 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_1) {
+		return 1;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_2) {
+		return 2;
+	}
+	else if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_3) {
+		return 3;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/sifive-hifive-unleashed/metal.ramrodata.lds
+++ b/bsp/sifive-hifive-unleashed/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive-unleashed/metal.scratchpad.lds
+++ b/bsp/sifive-hifive-unleashed/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -29,6 +29,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive-unleashed/settings.mk
+++ b/bsp/sifive-hifive-unleashed/settings.mk
@@ -1,5 +1,12 @@
+# Copyright 2019 SiFive, Inc #
+# SPDX-License-Identifier: Apache-2.0 #
+# ----------------------------------- #
+# [XXXXX] 23-05-2019 13-29-50        #
+# ----------------------------------- #
+
 RISCV_ARCH=rv64imac
 RISCV_ABI=lp64
 RISCV_CMODEL=medany
 
 TARGET_TAGS=board openocd
+TARGET_DHRY_ITERS=20000000

--- a/bsp/sifive-hifive1-revb/metal-inline.h
+++ b/bsp/sifive-hifive1-revb/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/sifive-hifive1-revb/metal-platform.h
+++ b/bsp/sifive-hifive1-revb/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef SIFIVE_HIFIVE1_REVB__METAL_PLATFORM_H

--- a/bsp/sifive-hifive1-revb/metal.default.lds
+++ b/bsp/sifive-hifive1-revb/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive1-revb/metal.h
+++ b/bsp/sifive-hifive1-revb/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -230,6 +230,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/sifive-hifive1-revb/metal.ramrodata.lds
+++ b/bsp/sifive-hifive1-revb/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive1-revb/metal.scratchpad.lds
+++ b/bsp/sifive-hifive1-revb/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive1-revb/settings.mk
+++ b/bsp/sifive-hifive1-revb/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-35        #
+# [XXXXX] 23-05-2019 13-29-50        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=board jlink
+TARGET_DHRY_ITERS=20000000

--- a/bsp/sifive-hifive1/metal-inline.h
+++ b/bsp/sifive-hifive1/metal-inline.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -28,6 +28,7 @@ extern inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+extern inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu);
 extern inline struct metal_interrupt * __metal_driver_cpu_interrupt_controller(struct metal_cpu *cpu);
 extern inline int __metal_driver_cpu_num_pmp_regions(struct metal_cpu *cpu);

--- a/bsp/sifive-hifive1/metal-platform.h
+++ b/bsp/sifive-hifive1/metal-platform.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef SIFIVE_HIFIVE1__METAL_PLATFORM_H

--- a/bsp/sifive-hifive1/metal.default.lds
+++ b/bsp/sifive-hifive1/metal.default.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive1/metal.h
+++ b/bsp/sifive-hifive1/metal.h
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 #ifndef ASSEMBLY
@@ -228,6 +228,16 @@ static inline int __metal_driver_sifive_clint0_interrupt_lines(struct metal_inte
 
 
 /* --------------------- cpu ------------ */
+static inline int __metal_driver_cpu_hartid(struct metal_cpu *cpu)
+{
+	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
 static inline int __metal_driver_cpu_timebase(struct metal_cpu *cpu)
 {
 	if ((uintptr_t)cpu == (uintptr_t)&__metal_dt_cpu_0) {

--- a/bsp/sifive-hifive1/metal.ramrodata.lds
+++ b/bsp/sifive-hifive1/metal.ramrodata.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive1/metal.scratchpad.lds
+++ b/bsp/sifive-hifive1/metal.scratchpad.lds
@@ -1,7 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* ----------------------------------- */
-/* [XXXXX] 21-05-2019 10-54-35        */
+/* [XXXXX] 23-05-2019 13-29-50        */
 /* ----------------------------------- */
 
 OUTPUT_ARCH("riscv")
@@ -28,6 +28,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+	PROVIDE(__metal_boot_hart = 0);
 
 
 	.init 		:

--- a/bsp/sifive-hifive1/settings.mk
+++ b/bsp/sifive-hifive1/settings.mk
@@ -1,7 +1,7 @@
 # Copyright 2019 SiFive, Inc #
 # SPDX-License-Identifier: Apache-2.0 #
 # ----------------------------------- #
-# [XXXXX] 21-05-2019 10-54-35        #
+# [XXXXX] 23-05-2019 13-29-50        #
 # ----------------------------------- #
 
 RISCV_ARCH=rv32imac
@@ -9,3 +9,4 @@ RISCV_ABI=ilp32
 RISCV_CMODEL=medlow
 
 TARGET_TAGS=board openocd
+TARGET_DHRY_ITERS=20000000


### PR DESCRIPTION
DNM until Metal, Devicetree-Tools, and the updated examples are merged