### PR TITLE
Disable ramrodata for dhrystone on boards with 16k RAM

### DIFF
--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -39,7 +39,13 @@ endif
 
 ifeq ($(PROGRAM),dhrystone)
 ifeq ($(LINK_TARGET),)
-LINK_TARGET = ramrodata
+  ifneq ($(TARGET),freedom-e310-arty)
+  ifneq ($(TARGET),sifive-hifive1)
+  ifneq ($(TARGET),sifive-hifive1-revb)
+    LINK_TARGET = ramrodata
+  endif
+  endif
+  endif
 endif
 endif
 


### PR DESCRIPTION
We can't fit dhrystone with ramrodata on the Freedom E310 Arty or the HiFive1 boards.

There might be some tricks we can pull with a lot more work on the linker to make them fit, but in the meantime we at least need them to build and run.