### PR TITLE
Run U54-MC on Hart 0

### DIFF
--- a/bsp/coreip-u54mc-rtl/design.dts
+++ b/bsp/coreip-u54mc-rtl/design.dts
@@ -5,9 +5,6 @@
 	#size-cells = <2>;
 	compatible = "SiFive,FU540G-dev", "fu540-dev", "sifive-dev";
 	model = "SiFive,FU540G";
-	chosen {
-		metal,boothart = <&L13>;
-	};
 	L36: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/bsp/coreip-u54mc-rtl/metal.default.lds
+++ b/bsp/coreip-u54mc-rtl/metal.default.lds
@@ -27,7 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
-	PROVIDE(__metal_boot_hart = 1);
+	PROVIDE(__metal_boot_hart = 0);
 	PROVIDE(__metal_chicken_bit = 0);
 
 

--- a/bsp/coreip-u54mc-rtl/metal.ramrodata.lds
+++ b/bsp/coreip-u54mc-rtl/metal.ramrodata.lds
@@ -27,7 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
-	PROVIDE(__metal_boot_hart = 1);
+	PROVIDE(__metal_boot_hart = 0);
 	PROVIDE(__metal_chicken_bit = 0);
 
 

--- a/bsp/coreip-u54mc-rtl/metal.scratchpad.lds
+++ b/bsp/coreip-u54mc-rtl/metal.scratchpad.lds
@@ -27,7 +27,7 @@ SECTIONS
 	__stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
 	PROVIDE(__stack_size = __stack_size);
 	__heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
-	PROVIDE(__metal_boot_hart = 1);
+	PROVIDE(__metal_boot_hart = 0);
 	PROVIDE(__metal_chicken_bit = 0);
 
 

--- a/bsp/coreip-u54mc-rtl/settings.mk
+++ b/bsp/coreip-u54mc-rtl/settings.mk
@@ -3,8 +3,8 @@
 # ----------------------------------- #
 # ----------------------------------- #
 
-RISCV_ARCH=rv64imafdc
-RISCV_ABI=lp64d
+RISCV_ARCH=rv64imac
+RISCV_ABI=lp64
 RISCV_CMODEL=medany
 RISCV_SERIES=sifive-5-series
 


### PR DESCRIPTION
Something's broken about the boot hart support still. Switching back to hart 0 for u54mc so that we can get regression back up while I track it down.