### PR TITLE
Add make target to open local documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,15 @@ help:
 	@echo "    Exports a program for a single target into a standalone"
 	@echo "    project directory at STANDALONE_DEST."
 	@echo ""
-	@echo " For more information, view the Freedom E SDK Documentation at"
-	@echo "   https://sifive.github.io/freedom-e-sdk-docs/index.html"
+	@echo " open-docs"
+	@echo "    Opens the Freedom E SDK documentation in your HTML"
+	@echo "    viewer of choice. The documentation can also be found"
+	@echo "    online at"
+	@echo "      https://sifive.github.io/freedom-e-sdk-docs/index.html"
+
+.PHONY: open-docs
+open-docs: scripts/open-docs
+	$^
 
 .PHONY: clean
 clean:

--- a/scripts/open-docs
+++ b/scripts/open-docs
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+SDK_PATH="$( cd "$(dirname "$0")/.." ; pwd -P )"
+DOCS_PATH=$SDK_PATH/doc/html/index.html
+
+XDG_OPEN=`which xdg-open`
+OPEN=`which open`
+
+if [ "$XDG_OPEN" != "" ]; then
+        echo "Opening $DOCS_PATH"
+        $XDG_OPEN $DOCS_PATH
+
+elif [ "$OPEN" != "" ]; then
+        echo "Opening $DOCS_PATH"
+        $OPEN $DOCS_PATH
+
+else
+        echo "Please open $DOCS_PATH in your preferred HTML viewer"
+fi
+


### PR DESCRIPTION
We include a local copy of the documentation, so make it easy to read it.