### PR TITLE
Detect when we need to add metal,entry for FPGA targets

### DIFF
--- a/scripts/fixup-dts
+++ b/scripts/fixup-dts
@@ -105,6 +105,31 @@ if [ `grep -c 'stdout-path' ${dts}` -eq 0 ]; then
 fi
 
 
+# FPGA targets need a 0x400000 byte offset into their SPI flash
+
+# Is the target an FPGA?
+if [ `echo ${dts} | grep -c 'arty'` -ne 0 -o `echo ${dts} | grep -c 'fpga'` -ne 0 ] ; then
+    # Is there a metal,entry property in the chosen node?
+    if [ `grep -c 'metal,entry' ${dts}` -eq 0 ] ; then
+        echo "$0: FPGA target needs metal,entry property to set boot offset."
+
+        # Find the SPI device with the lowest base address
+        first_spi_node=`grep -oE "spi@[[:xdigit:]]+?" ${dts} | sort | head -n 1`
+
+        # Get the DTS node label of that SPI device
+        spi_entry_label=`grep -oE "[^[:space:]]+?:\s+?${first_spi_node}" ${dts} | cut -d ':' -f 1`
+
+        if [ `grep -c 'chosen' ${dts}` -eq 0 ]; then
+            ${SED} -i "/cpus/i chosen {\n};" ${dts}
+        fi
+
+        ${SED} -i "/chosen/a metal,entry = <&${spi_entry_label} 0x400000>;" ${dts}
+
+        echo -e "$0: \tAdded metal,entry for SPI node ${first_spi_node} with label ${spi_entry_label}"
+    fi
+fi
+
+
 # Add a test memory node if one doesn't exist
 
 if [ `grep -c 'sifive,testram0' ${dts}` -eq 0 ]; then


### PR DESCRIPTION
Automatically add a 0x400000 byte offset to the entry point of FPGA and
Arty targets