### PR TITLE
DTS Fixup bug fixes

### DIFF
--- a/scripts/fixup-dts
+++ b/scripts/fixup-dts
@@ -129,7 +129,7 @@ if [ `grep -c 'sifive,testram0' ${dts}` -eq 0 ]; then
                 if [ `grep -c "${protocol}-${port_type}-port" ${dts}` -ne 0 ]; then
                     
                     # Build the node name
-                    port_node_name=`egrep -o "${protocol}-${port_type}-port@[a-fA-F0-9]+" ${dts}`
+                    port_node_name=`egrep -o "${protocol}-${port_type}-port@[a-fA-F0-9]+" ${dts} | head -n 1`
                     echo -e "$0: \tUsing node \t${port_node_name}"
 
                     # Get the address and size cells

--- a/scripts/fixup-dts
+++ b/scripts/fixup-dts
@@ -140,19 +140,19 @@ if [ `grep -c 'sifive,testram0' ${dts}` -eq 0 ]; then
 
                     # Get the base address and size
                     if [ ${address_cells} -eq 1 -a ${size_cells} -eq 1 ]; then
-                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x\d+ \K(0x\d+ 0x\d+)"`)
+                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x[[:xdigit:]]+ \K(0x[[:xdigit:]]+ 0x[[:xdigit:]]+)"`)
                         base_address=${address_and_size[0]}
                         size=${address_and_size[1]}
                     elif [ ${address_cells} -eq 1 -a ${size_cells} -eq 2 ]; then
-                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x\d+ \K(0x\d+ 0x\d+ 0x\d+)"`)
+                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x[[:xdigit:]]+ \K(0x[[:xdigit:]]+ 0x[[:xdigit:]]+ 0x[[:xdigit:]]+)"`)
                         base_address=${address_and_size[0]}
                         size="${address_and_size[1]} ${address_and_size[2]}"
                     elif [ ${address_cells} -eq 2 -a ${size_cells} -eq 1 ]; then
-                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x\d+ 0x\d+ \K(0x\d+ 0x\d+ 0x\d+)"`)
+                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x[[:xdigit:]]+ 0x[[:xdigit:]]+ \K(0x[[:xdigit:]]+ 0x[[:xdigit:]]+ 0x[[:xdigit:]]+)"`)
                         base_address="${address_and_size[0]} ${address_and_size[1]}"
                         size=${address_and_size[2]}
                     elif [ ${address_cells} -eq 2 -a ${size_cells} -eq 2 ]; then
-                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x\d+ 0x\d+ \K(0x\d+ 0x\d+ 0x\d+ 0x\d+)"`)
+                        address_and_size=(`cat ${dts} | tr -d '\n\t' | grep -oP "${port_node_name}.*?ranges = <0x[[:xdigit:]]+ 0x[[:xdigit:]]+ \K(0x[[:xdigit:]]+ 0x[[:xdigit:]]+ 0x[[:xdigit:]]+ 0x[[:xdigit:]]+)"`)
                         base_address="${address_and_size[0]} ${address_and_size[1]}"
                         size="${address_and_size[2]} ${address_and_size[3]}"
                     fi


### PR DESCRIPTION
Designs can have multiple ports with the same protocol and port type, so fixup-dts will pick the first one.

fixup-dts also needs to look for hex, not decimal digits, so update the regexes to match.