### PR TITLE
Update targets.sh sh to bash

### DIFF
--- a/bsp/update-targets.sh
+++ b/bsp/update-targets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 help() {
     cat >&2 <<EOF


### PR DESCRIPTION
One liner to fix the shabang of a file.

The `update-targets.sh` file is using `bash`-specific syntax in an `if` statement around line 42 that was throwing errors when you run it via `sh`.