### PR TITLE
Fix DeviceTree tools submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,4 +57,4 @@
 	url = https://github.com/sifive/benchmark-coremark.git
 [submodule "freedom-devicetree-tools"]
 	path = freedom-devicetree-tools
-	url = git@github.com:sifive/freedom-devicetree-tools.git
+	url = https://github.com/sifive/freedom-devicetree-tools.git


### PR DESCRIPTION
Use the HTTPS URL instead of SSH