### PR TITLE
Disable Segger's ISA simulator

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -33,6 +33,7 @@ if [ "$jlink" != "" ]
 then
 
 $jlink -device RISC-V -port $GDB_PORT &
+extra_gdb=("-ex" "monitor allowsimulation 0")
 
 else
 
@@ -40,6 +41,6 @@ $openocd -f $cfg &
 
 fi
 
-$gdb $elf -ex "set remotetimeout 240" -ex "target extended-remote localhost:${GDB_PORT}"
+$gdb $elf -ex "set remotetimeout 240" -ex "target extended-remote localhost:${GDB_PORT}" "${extra_gdb[@]}"
 
 kill %1


### PR DESCRIPTION
It appears that Segger will simulate some instructions, presumably to
speed up stepping past a breakpoint.  I just spent a day or so dealing
with a bug in that simulator, so let's just disable it for now.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>