### PR TITLE
Restore standalone target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ endif
 	cp release.mk $</release.mk
 
 	echo "PROGRAM = $(PROGRAM)" > $</Makefile
+	echo "TARGET = ${TARGET}" >> $</Makefile
 ifneq ($(PORT_DIR),)
 	echo "PORT_DIR = $(PORT_DIR)" >> $</Makefile
 endif
@@ -260,6 +261,7 @@ endif
 	cp release.mk $</release.mk
 
 	echo "PROGRAM = $(PROGRAM)" > $</Makefile
+	echo "TARGET = ${TARGET}" >> $</Makefile
 ifneq ($(PORT_DIR),)
 	echo "PORT_DIR = $(PORT_DIR)" >> $</Makefile
 endif


### PR DESCRIPTION
Nate, Not sure if this was dropped accidentally or not, but 19.05 does not define ${TARGET} in the generated standalone makefiles, yet the makefile references the variable in a few places. 