### PR TITLE
[v19.08] Don't use newlib-nano for Dhrystone

### DIFF
--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -113,10 +113,13 @@ RISCV_CXXFLAGS += -ffunction-sections -fdata-sections
 RISCV_CCASFLAGS += -I$(abspath $(BSP_DIR)/install/include/)
 RISCV_CFLAGS    += -I$(abspath $(BSP_DIR)/install/include/)
 RISCV_CXXFLAGS  += -I$(abspath $(BSP_DIR)/install/include/)
+
+ifneq ($(PROGRAM),dhrystone)
 # Use newlib-nano
 RISCV_CCASFLAGS += --specs=nano.specs
 RISCV_CFLAGS    += --specs=nano.specs
 RISCV_CXXFLAGS  += --specs=nano.specs
+endif
 
 # Turn on garbage collection for unused sections
 RISCV_LDFLAGS += -Wl,--gc-sections

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -15,7 +15,7 @@
         "source": "git@github.com:sifive/elf2hex.git"
     },
     {
-        "commit": "8ff0ab1db77b134b56815905bf694eb8a767285b",
+        "commit": "9a102bc2936a921e4da79cdf396189faaa98f242",
         "name": "benchmark-dhrystone",
         "source": "git@github.com:sifive/benchmark-dhrystone.git"
     },


### PR DESCRIPTION
newlib-nano is optimized for size, not performance, so only enable it for non-dhrystone programs