### PR TITLE
[v19.08] DTS Fixup: Use sifive,trace as stdout-path

### DIFF
--- a/scripts/fixup-dts
+++ b/scripts/fixup-dts
@@ -71,7 +71,7 @@ if [ `grep -c 'stdout-path' ${dts}` -eq 0 ]; then
     if [ `grep -c 'sifive,uart0' ${dts}` -ne 0 ]; then
         echo "$0: stdout-path property not given, but a UART device exists."
 
-        serial_node=`grep -oP "serial@\d+" ${dts} | sort | uniq | head -n 1`
+        serial_node=`grep -oP "serial@[[:xdigit:]]+" ${dts} | sort | uniq | head -n 1`
         serial_path="/soc/${serial_node}:115200"
 
         if [ `grep -c 'chosen' ${dts}` -eq 0 ]; then
@@ -81,6 +81,21 @@ if [ `grep -c 'stdout-path' ${dts}` -eq 0 ]; then
         ${SED} -i "/chosen/a stdout-path=\"${serial_path}\";" ${dts}
 
         echo -e "$0: \tAdded stdout-path ${serial_path}"
+
+    # If no UART exists, use the trace encoder
+    elif [ `grep -c 'sifive,trace' ${dts}` -ne 0 ]; then
+        echo "$0: stdout-path property not given, but a trace encoder exists."
+
+        trace_node=`grep -oP "trace@[[:xdigit:]]+" ${dts} | sort | uniq | head -n 1`
+        trace_path="/soc/${trace_node}:115200"
+
+        if [ `grep -c 'chosen' ${dts}` -eq 0 ]; then
+            ${SED} -i "/cpus/i chosen {\n};" ${dts}
+        fi
+
+        ${SED} -i "/chosen/a stdout-path=\"${trace_path}\";" ${dts}
+
+        echo -e "$0: \tAdded stdout-path ${trace_path}"
     fi
 fi
 


### PR DESCRIPTION
If a trace encoder exists, no stdout-path is specified in the chosen
node, and no UART exists, then use the sifive,trace device as the
stdout-path