### PR TITLE
Support for using elf2hex from sdk-utilities package

### DIFF
--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -211,10 +211,16 @@ $(PROGRAM_ELF): \
 # Use elf2hex if we're creating a hex file for RTL simulation
 ifneq ($(filter rtl,$(TARGET_TAGS)),)
 .PHONY: software
+ifeq ($(FREEDOM_SDK_TOOLS_PATH),)
 $(PROGRAM_HEX): \
 		scripts/elf2hex/install/bin/$(CROSS_COMPILE)-elf2hex \
 		$(PROGRAM_ELF)
 	$< --output $@ --input $(PROGRAM_ELF) --bit-width $(COREIP_MEM_WIDTH)
+else
+$(PROGRAM_HEX): \
+		$(PROGRAM_ELF)
+	$(FREEDOM_SDK_TOOLS_PATH)/bin/$(CROSS_COMPILE)-elf2hex --output $@ --input $(PROGRAM_ELF) --bit-width $(COREIP_MEM_WIDTH)
+endif
 else
 $(PROGRAM_HEX): \
 		$(PROGRAM_ELF)


### PR DESCRIPTION
When using the python based elf2hex, FreedomStudio/Eclipse detects some of the output messages as errors, which is not pleasant for users.

The sdk-utilities package is already bundled with FreedomStudio, and when FS builds a standalone project it sets the FREEDOM_SDK_TOOLS_PATH env var to point to the bundled sdk-utilities package.

With this code addition, it makes FS build use the bundled precompiled C-based elf2hex, thereby also making the build faster - which is also possible from command line builds.
