### PR TITLE
[v19.08] Bump Devicetree tools for mem range selection

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "84479ce21b4334fd44fcb36a6151c9f934da0222",
+        "commit": "c938d8172861166cb6d662f3ef8febc0977d2627",
         "name": "freedom-devicetree-tools",
         "source": "git@github.com:sifive/freedom-devicetree-tools.git"
     },


### PR DESCRIPTION
Backports a fix from master.

Changes the linker script generator strategy to pick the first tuple of
ranges in the memory node.