### PR TITLE
Fix issue of USE_LIBC_SEGGER=0 or 1 has the same behavior

### DIFF
--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -136,10 +136,11 @@ RISCV_LDFLAGS += -nostartfiles -nostdlib
 RISCV_LDFLAGS += -L$(sort $(dir $(abspath $(filter %.a,$^)))) -T$(abspath $(filter %.lds,$^))
 
 # Link to the relevant libraries
-RISCV_LDLIBS += -Wl,--start-group -lc -lm -lgcc -lmetal -lmetal-gloss -Wl,--end-group
+RISCV_LDLIBS_GROUP  := -Wl,--start-group -lc -lm -lgcc -lmetal -lmetal-gloss -Wl,--end-group
 ifeq ($(USE_LIBC_SEGGER),1)
-RISCV_LDLIBS += -Wl,--start-group -lc_segger -ltarget_metal -lmetal -lmetal-gloss -Wl,--end-group
+RISCV_LDLIBS_GROUP  := -Wl,--start-group -lc_segger -ltarget_metal -lmetal -lmetal-gloss -Wl,--end-group
 endif
+RISCV_LDLIBS += $(RISCV_LDLIBS_GROUP)
 
 # Load the configuration Makefile
 CONFIGURATION_FILE = $(wildcard $(CONFIGURATION).mk)

--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -115,7 +115,7 @@ RISCV_CFLAGS    += -I$(abspath $(BSP_DIR)/install/include/)
 RISCV_CXXFLAGS  += -I$(abspath $(BSP_DIR)/install/include/)
 
 # Use newlib-nano
-ifeq ($(USE_LIBC_SEGGER),)
+ifeq ($(USE_LIBC_SEGGER),0)
 METAL_CFLAGS	:= $(RISCV_CFLAGS) -Os
 RISCV_CCASFLAGS += --specs=nano.specs
 RISCV_CFLAGS    += --specs=nano.specs
@@ -137,7 +137,7 @@ RISCV_LDFLAGS += -nostartfiles -nostdlib
 RISCV_LDFLAGS += -L$(sort $(dir $(abspath $(filter %.a,$^)))) -T$(abspath $(filter %.lds,$^))
 
 # Link to the relevant libraries
-ifeq ($(USE_LIBC_SEGGER),)
+ifeq ($(USE_LIBC_SEGGER),0)
 RISCV_LDLIBS += -Wl,--start-group -lc -lm -lgcc -lmetal -lmetal-gloss -Wl,--end-group
 else
 RISCV_LDLIBS += -Wl,--start-group -lc_segger -ltarget_metal -lmetal -lmetal-gloss -Wl,--end-group

--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -115,17 +115,16 @@ RISCV_CFLAGS    += -I$(abspath $(BSP_DIR)/install/include/)
 RISCV_CXXFLAGS  += -I$(abspath $(BSP_DIR)/install/include/)
 
 # Use newlib-nano
-ifeq ($(USE_LIBC_SEGGER),0)
 METAL_CFLAGS	:= $(RISCV_CFLAGS) -Os
-RISCV_CCASFLAGS += --specs=nano.specs
-RISCV_CFLAGS    += --specs=nano.specs
-RISCV_CXXFLAGS  += --specs=nano.specs
-else
+SPECS_NAME  := --specs=nano.specs
+ifeq ($(USE_LIBC_SEGGER),1)
 METAL_CFLAGS	:= $(RISCV_CFLAGS) -Os -D__SEGGER_LIBC__ -isystem =/include/segger
-RISCV_CCASFLAGS += --specs=segger-metal.specs
-RISCV_CFLAGS    += --specs=segger-metal.specs
-RISCV_CXXFLAGS  += --specs=segger-metal.specs
+SPECS_NAME  := --specs=segger-metal.specs
 endif
+RISCV_CCASFLAGS += $(SPECS_NAME)
+RISCV_CFLAGS    += $(SPECS_NAME)
+RISCV_CXXFLAGS  += $(SPECS_NAME)
+
 
 # Turn on garbage collection for unused sections
 RISCV_LDFLAGS += -Wl,--gc-sections
@@ -137,9 +136,8 @@ RISCV_LDFLAGS += -nostartfiles -nostdlib
 RISCV_LDFLAGS += -L$(sort $(dir $(abspath $(filter %.a,$^)))) -T$(abspath $(filter %.lds,$^))
 
 # Link to the relevant libraries
-ifeq ($(USE_LIBC_SEGGER),0)
 RISCV_LDLIBS += -Wl,--start-group -lc -lm -lgcc -lmetal -lmetal-gloss -Wl,--end-group
-else
+ifeq ($(USE_LIBC_SEGGER),1)
 RISCV_LDLIBS += -Wl,--start-group -lc_segger -ltarget_metal -lmetal -lmetal-gloss -Wl,--end-group
 endif
 


### PR DESCRIPTION
* Original behavior:
    always use segger library whatever USE_LIBC_SEGGER=0 or 1
* Behavior after fixing:
    using nano library when USE_LIBC_SEGGER=0.
    using segger library when USE_LIBC_SEGGER=1.
    using nano library when USE_LIBC_SEGGER not apply.
