### PR TITLE
Update standalone.mk

### DIFF
--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -202,8 +202,8 @@ $(PROGRAM_ELF): \
 		XCFLAGS="$(RISCV_XCFLAGS)" \
 		LDFLAGS="$(RISCV_LDFLAGS)" \
 		LDLIBS="$(RISCV_LDLIBS)"
-	mv $(SRC_DIR)/$(basename $(notdir $@)).map $(dir $@)
 	mv $(SRC_DIR)/$(basename $(notdir $@)) $@
+	mv $(SRC_DIR)/$(basename $(notdir $@)).map $(dir $@)
 	touch -c $@
 	$(RISCV_OBJDUMP) --source --all-headers --demangle --line-numbers --wide $@ > $(PROGRAM_LST)
 	$(RISCV_SIZE) $@


### PR DESCRIPTION
Do not move the .map file until after successfully moving the ELF file to its destination.

This change fixes a case where the user attempts to rebuild the ELF file while it is being used by the debugger.  The build fails because the ELF file is held open by the debugger.  After the debug session is closed the build continues to fail because the MAP file (which was moved in the previous failed build) no longer exists in the source directory.

Swapping the two `mv` commands prevents moving the MAP file until after the ELF file has been successfully moved.

This should go into 19.11.