### PR TITLE
Updating svd files and generation from review comments

### DIFF
--- a/bsp/freedom-e310-arty/design.svd
+++ b/bsp/freedom-e310-arty/design.svd
@@ -11,7 +11,31 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>pwm_10015000</name>
+      <name>riscv_clint0_0</name>
+      <description>From riscv,clint0,control peripheral generator</description>
+      <baseAddress>0x2000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_pwm0_0</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10015000</baseAddress>
       <addressBlock>
@@ -22,7 +46,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -31,12 +54,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -57,12 +74,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -73,12 +84,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -179,14 +184,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -196,23 +194,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -222,35 +207,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -260,17 +220,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -280,17 +233,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -300,17 +246,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -320,18 +259,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>gpio_10012000</name>
+      <name>sifive_gpio0_0</name>
       <description>From sifive,gpio0,control peripheral generator</description>
       <baseAddress>0x10012000</baseAddress>
       <addressBlock>
@@ -342,110 +275,93 @@
       <registers>
         <register>
           <name>input_val</name>
-          <displayName></displayName>
           <description>Pin value</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>input_en</name>
-          <displayName></displayName>
           <description>Pin input enable</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>output_en</name>
-          <displayName></displayName>
           <description>Pin output enable</description>
           <addressOffset>0x8</addressOffset>
         </register>
         <register>
           <name>output_val</name>
-          <displayName></displayName>
           <description>Output value</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>pue</name>
-          <displayName></displayName>
           <description>Internal pull-up enable</description>
           <addressOffset>0x10</addressOffset>
         </register>
         <register>
           <name>ds</name>
-          <displayName></displayName>
           <description>Pin drive strength</description>
           <addressOffset>0x14</addressOffset>
         </register>
         <register>
           <name>rise_ie</name>
-          <displayName></displayName>
           <description>Rise interrupt enable</description>
           <addressOffset>0x18</addressOffset>
         </register>
         <register>
           <name>rise_ip</name>
-          <displayName></displayName>
           <description>Rise interrupt pending</description>
           <addressOffset>0x1C</addressOffset>
         </register>
         <register>
           <name>fall_ie</name>
-          <displayName></displayName>
           <description>Fall interrupt enable</description>
           <addressOffset>0x20</addressOffset>
         </register>
         <register>
           <name>fall_ip</name>
-          <displayName></displayName>
           <description>Fall interrupt pending</description>
           <addressOffset>0x24</addressOffset>
         </register>
         <register>
           <name>high_ie</name>
-          <displayName></displayName>
           <description>High interrupt enable</description>
           <addressOffset>0x28</addressOffset>
         </register>
         <register>
           <name>high_ip</name>
-          <displayName></displayName>
           <description>High interrupt pending</description>
           <addressOffset>0x2C</addressOffset>
         </register>
         <register>
           <name>low_ie</name>
-          <displayName></displayName>
           <description>Low interrupt enable</description>
           <addressOffset>0x30</addressOffset>
         </register>
         <register>
           <name>low_ip</name>
-          <displayName></displayName>
           <description>Low interrupt pending</description>
           <addressOffset>0x34</addressOffset>
         </register>
         <register>
           <name>iof_en</name>
-          <displayName></displayName>
           <description>I/O function enable</description>
           <addressOffset>0x38</addressOffset>
         </register>
         <register>
           <name>iof_sel</name>
-          <displayName></displayName>
           <description>I/O function select</description>
           <addressOffset>0x3C</addressOffset>
         </register>
         <register>
           <name>out_xor</name>
-          <displayName></displayName>
           <description>Output XOR (invert)</description>
           <addressOffset>0x40</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10013000</name>
+      <name>sifive_uart0_0</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10013000</baseAddress>
       <addressBlock>
@@ -456,7 +372,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -464,12 +379,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -482,7 +391,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -491,12 +399,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -508,7 +410,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -525,28 +426,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -557,28 +445,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -594,17 +469,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -620,17 +488,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -640,18 +501,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10014000</name>
+      <name>sifive_spi0_0</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10014000</baseAddress>
       <addressBlock>
@@ -662,7 +517,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -672,17 +526,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -698,29 +545,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -734,7 +562,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -748,7 +575,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -758,35 +584,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -797,28 +598,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -829,40 +617,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -878,17 +641,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -898,17 +654,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -931,34 +680,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -966,12 +696,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -984,7 +708,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -993,12 +716,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1010,7 +727,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -1020,17 +736,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -1040,29 +749,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -1072,17 +762,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -1123,12 +806,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -1143,20 +820,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -1172,17 +836,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -1197,12 +854,6 @@
               <description>Receive watermark pending</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
             </field>
           </fields>
         </register>

--- a/bsp/qemu-sifive-e31/design.svd
+++ b/bsp/qemu-sifive-e31/design.svd
@@ -11,7 +11,7 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>test_100000</name>
+      <name>sifive_test0_0</name>
       <description>From sifive,test0,control peripheral generator</description>
       <baseAddress>0x100000</baseAddress>
       <addressBlock>
@@ -22,7 +22,6 @@
       <registers>
         <register>
           <name>finisher</name>
-          <displayName>Test Finisher Register</displayName>
           <description>Test finisher register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -43,7 +42,7 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>aon_10000000</name>
+      <name>sifive_aon0_0</name>
       <description>From sifive,aon0,mem peripheral generator</description>
       <baseAddress>0x10000000</baseAddress>
       <addressBlock>
@@ -144,12 +143,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogrsten</name>
               <description>Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.</description>
               <bitRange>[8:8]</bitRange>
@@ -160,18 +153,6 @@
               <description>Reset counter to zero after match.</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>wdogenalways</name>
@@ -186,58 +167,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -245,11 +178,6 @@
           <name>wdogcount</name>
           <description>Counter Register</description>
           <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>reserved_C</name>
-          <description>Register reserved_C</description>
-          <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>wdogs</name>
@@ -283,100 +211,16 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_8_8</name>
-              <description>Field reserved_8_8</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_9_9</name>
-              <description>Field reserved_9_9</description>
-              <bitRange>[9:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcenalways</name>
               <description>Enable Always - run continuously</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_13_13</name>
-              <description>Field reserved_13_13</description>
-              <bitRange>[13:13]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -394,16 +238,6 @@
           <name>rtcs</name>
           <description>Scaled value of Counter</description>
           <addressOffset>0x50</addressOffset>
-        </register>
-        <register>
-          <name>reserved_58</name>
-          <description>Register reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>reserved_5C</name>
-          <description>Register reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
         </register>
         <register>
           <name>rtccmp0</name>
@@ -511,99 +345,50 @@
           <addressOffset>0x14C</addressOffset>
         </register>
         <register>
-          <name>AONCFG</name>
+          <name>aoncfg</name>
           <description>AON Block Configuration Information</description>
           <addressOffset>0x300</addressOffset>
           <fields>
             <field>
-              <name>HAS_BANDGAP</name>
+              <name>has_bandgap</name>
               <description>Bandgap feature is present</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_BOD</name>
+              <name>has_bod</name>
               <description>Brownout detector feature is present</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFROSC</name>
+              <name>has_lfrosc</name>
               <description>Low Frequency Ring Oscillator feature is present</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFRCOSC</name>
+              <name>has_lfrcosc</name>
               <description>Low Frequency RC Oscillator feature is present</description>
               <bitRange>[3:3]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFXOSC</name>
+              <name>has_lfxosc</name>
               <description>Low Frequency Crystal Oscillator feature is present</description>
               <bitRange>[4:4]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_POR</name>
+              <name>has_por</name>
               <description>Power-On-Reset feature is present</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LDO</name>
+              <name>has_ldo</name>
               <description>Low Dropout Regulator feature is present</description>
               <bitRange>[6:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_7</name>
-              <description>Field reserved_31_7</description>
-              <bitRange>[31:7]</bitRange>
-              <access>read-only</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>SiFiveBandgap</name>
-          <description>Bandgap configuration</description>
-          <addressOffset>0x210</addressOffset>
-          <fields>
-            <field>
-              <name>EN</name>
-              <description>Bandgap enable</description>
-              <bitRange>[0:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_7_1</name>
-              <description>Field reserved_7_1</description>
-              <bitRange>[7:1]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>DIS</name>
-              <description>Bandgap disable</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_9</name>
-              <description>Field reserved_15_9</description>
-              <bitRange>[15:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>TRIM</name>
-              <description>Bandgap trim value</description>
-              <bitRange>[19:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_23_20</name>
-              <description>Field reserved_23_20</description>
-              <bitRange>[23:20]</bitRange>
               <access>read-only</access>
             </field>
           </fields>
@@ -620,22 +405,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>lfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfroscen</name>
@@ -663,22 +436,16 @@
               <access>read-write</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>INTERNAL</name>
+                  <name>internal</name>
                   <description>Use internal LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>1</value>
                 </enumeratedValue>
               </enumeratedValues>
-            </field>
-            <field>
-              <name>reserved_30_1</name>
-              <description>Field reserved_30_1</description>
-              <bitRange>[30:1]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfextclk_mux_status</name>
@@ -687,12 +454,12 @@
               <access>read-only</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>SW</name>
+                  <name>sw</name>
                   <description>Use clock source selected by lfextclk_sel</description>
                   <value>1</value>
                 </enumeratedValue>
@@ -703,7 +470,7 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>prci_10008000</name>
+      <name>sifive_fe310_g000_prci_0</name>
       <description>From sifive,fe310-g000,prci,mem peripheral generator</description>
       <baseAddress>0x10008000</baseAddress>
       <addressBlock>
@@ -724,22 +491,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>hfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>hfroscen</name>
@@ -760,12 +515,6 @@
           <description>Crystal Oscillator Configuration and Status</description>
           <addressOffset>0x4</addressOffset>
           <fields>
-            <field>
-              <name>reserved_29_0</name>
-              <description>Field reserved_29_0</description>
-              <bitRange>[29:0]</bitRange>
-              <access>read-only</access>
-            </field>
             <field>
               <name>hfxoscen</name>
               <description>Crystal Oscillator Enable</description>
@@ -792,12 +541,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_3_3</name>
-              <description>Field reserved_3_3</description>
-              <bitRange>[3:3]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pllf</name>
               <description>PLL F Value</description>
               <bitRange>[9:4]</bitRange>
@@ -808,12 +551,6 @@
               <description>PLL Q Value</description>
               <bitRange>[11:10]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_12</name>
-              <description>Field reserved_15_12</description>
-              <bitRange>[15:12]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pllsel</name>
@@ -832,12 +569,6 @@
               <description>PLL Bypass</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_30_19</name>
-              <description>Field reserved_30_19</description>
-              <bitRange>[30:19]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>plllock</name>
@@ -859,12 +590,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_6</name>
-              <description>Field reserved_7_6</description>
-              <bitRange>[7:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>plloutdivby1</name>
               <description>PLL Final Divide By 1</description>
               <bitRange>[13:8]</bitRange>
@@ -884,22 +609,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_5</name>
-              <description>Field reserved_7_5</description>
-              <bitRange>[7:5]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procmon_delay_sel</name>
               <description>Process Monitor Delay Selector</description>
               <bitRange>[12:8]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_13</name>
-              <description>Field reserved_15_13</description>
-              <bitRange>[15:13]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>procmon_en</name>
@@ -908,41 +621,41 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_23_17</name>
-              <description>Field reserved_23_17</description>
-              <bitRange>[23:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procomon_sel</name>
               <description>Process Monitor Select</description>
               <bitRange>[25:24]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_27_26</name>
-              <description>Field reserved_27_26</description>
-              <bitRange>[27:26]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_28_28</name>
-              <description>Field reserved_28_28</description>
-              <bitRange>[28:28]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10015000</name>
+      <name>riscv_clint0_0</name>
+      <description>From riscv,clint0,control peripheral generator</description>
+      <baseAddress>0x2000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_pwm0_0</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10015000</baseAddress>
       <addressBlock>
@@ -953,7 +666,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -962,12 +674,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -988,12 +694,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -1004,12 +704,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -1110,14 +804,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1127,23 +814,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1153,35 +827,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -1191,17 +840,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -1211,17 +853,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1231,17 +866,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1251,18 +879,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>gpio_10012000</name>
+      <name>sifive_gpio0_0</name>
       <description>From sifive,gpio0,control peripheral generator</description>
       <baseAddress>0x10012000</baseAddress>
       <addressBlock>
@@ -1273,110 +895,93 @@
       <registers>
         <register>
           <name>input_val</name>
-          <displayName></displayName>
           <description>Pin value</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>input_en</name>
-          <displayName></displayName>
           <description>Pin input enable</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>output_en</name>
-          <displayName></displayName>
           <description>Pin output enable</description>
           <addressOffset>0x8</addressOffset>
         </register>
         <register>
           <name>output_val</name>
-          <displayName></displayName>
           <description>Output value</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>pue</name>
-          <displayName></displayName>
           <description>Internal pull-up enable</description>
           <addressOffset>0x10</addressOffset>
         </register>
         <register>
           <name>ds</name>
-          <displayName></displayName>
           <description>Pin drive strength</description>
           <addressOffset>0x14</addressOffset>
         </register>
         <register>
           <name>rise_ie</name>
-          <displayName></displayName>
           <description>Rise interrupt enable</description>
           <addressOffset>0x18</addressOffset>
         </register>
         <register>
           <name>rise_ip</name>
-          <displayName></displayName>
           <description>Rise interrupt pending</description>
           <addressOffset>0x1C</addressOffset>
         </register>
         <register>
           <name>fall_ie</name>
-          <displayName></displayName>
           <description>Fall interrupt enable</description>
           <addressOffset>0x20</addressOffset>
         </register>
         <register>
           <name>fall_ip</name>
-          <displayName></displayName>
           <description>Fall interrupt pending</description>
           <addressOffset>0x24</addressOffset>
         </register>
         <register>
           <name>high_ie</name>
-          <displayName></displayName>
           <description>High interrupt enable</description>
           <addressOffset>0x28</addressOffset>
         </register>
         <register>
           <name>high_ip</name>
-          <displayName></displayName>
           <description>High interrupt pending</description>
           <addressOffset>0x2C</addressOffset>
         </register>
         <register>
           <name>low_ie</name>
-          <displayName></displayName>
           <description>Low interrupt enable</description>
           <addressOffset>0x30</addressOffset>
         </register>
         <register>
           <name>low_ip</name>
-          <displayName></displayName>
           <description>Low interrupt pending</description>
           <addressOffset>0x34</addressOffset>
         </register>
         <register>
           <name>iof_en</name>
-          <displayName></displayName>
           <description>I/O function enable</description>
           <addressOffset>0x38</addressOffset>
         </register>
         <register>
           <name>iof_sel</name>
-          <displayName></displayName>
           <description>I/O function select</description>
           <addressOffset>0x3C</addressOffset>
         </register>
         <register>
           <name>out_xor</name>
-          <displayName></displayName>
           <description>Output XOR (invert)</description>
           <addressOffset>0x40</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10013000</name>
+      <name>sifive_uart0_0</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10013000</baseAddress>
       <addressBlock>
@@ -1387,7 +992,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1395,12 +999,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1413,7 +1011,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1422,12 +1019,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1439,7 +1030,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1456,28 +1046,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -1488,28 +1065,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1525,17 +1089,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1551,17 +1108,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1571,18 +1121,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10014000</name>
+      <name>sifive_spi0_0</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10014000</baseAddress>
       <addressBlock>
@@ -1593,7 +1137,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1603,17 +1146,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1629,29 +1165,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1665,7 +1182,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1679,7 +1195,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1689,35 +1204,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1728,28 +1218,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1760,40 +1237,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -1809,17 +1261,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -1829,17 +1274,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -1862,34 +1300,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -1897,12 +1316,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1915,7 +1328,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -1924,12 +1336,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1941,7 +1347,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -1951,17 +1356,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -1971,29 +1369,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -2003,17 +1382,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -2054,12 +1426,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -2074,20 +1440,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -2103,17 +1456,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -2128,12 +1474,6 @@
               <description>Receive watermark pending</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
             </field>
           </fields>
         </register>

--- a/bsp/qemu-sifive-s51/design.svd
+++ b/bsp/qemu-sifive-s51/design.svd
@@ -11,7 +11,7 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>test_100000</name>
+      <name>sifive_test0_0</name>
       <description>From sifive,test0,control peripheral generator</description>
       <baseAddress>0x100000</baseAddress>
       <addressBlock>
@@ -22,7 +22,6 @@
       <registers>
         <register>
           <name>finisher</name>
-          <displayName>Test Finisher Register</displayName>
           <description>Test finisher register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -43,7 +42,7 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>aon_10000000</name>
+      <name>sifive_aon0_0</name>
       <description>From sifive,aon0,mem peripheral generator</description>
       <baseAddress>0x10000000</baseAddress>
       <addressBlock>
@@ -144,12 +143,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogrsten</name>
               <description>Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.</description>
               <bitRange>[8:8]</bitRange>
@@ -160,18 +153,6 @@
               <description>Reset counter to zero after match.</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>wdogenalways</name>
@@ -186,58 +167,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -245,11 +178,6 @@
           <name>wdogcount</name>
           <description>Counter Register</description>
           <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>reserved_C</name>
-          <description>Register reserved_C</description>
-          <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>wdogs</name>
@@ -283,100 +211,16 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_8_8</name>
-              <description>Field reserved_8_8</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_9_9</name>
-              <description>Field reserved_9_9</description>
-              <bitRange>[9:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcenalways</name>
               <description>Enable Always - run continuously</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_13_13</name>
-              <description>Field reserved_13_13</description>
-              <bitRange>[13:13]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -394,16 +238,6 @@
           <name>rtcs</name>
           <description>Scaled value of Counter</description>
           <addressOffset>0x50</addressOffset>
-        </register>
-        <register>
-          <name>reserved_58</name>
-          <description>Register reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>reserved_5C</name>
-          <description>Register reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
         </register>
         <register>
           <name>rtccmp0</name>
@@ -511,99 +345,50 @@
           <addressOffset>0x14C</addressOffset>
         </register>
         <register>
-          <name>AONCFG</name>
+          <name>aoncfg</name>
           <description>AON Block Configuration Information</description>
           <addressOffset>0x300</addressOffset>
           <fields>
             <field>
-              <name>HAS_BANDGAP</name>
+              <name>has_bandgap</name>
               <description>Bandgap feature is present</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_BOD</name>
+              <name>has_bod</name>
               <description>Brownout detector feature is present</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFROSC</name>
+              <name>has_lfrosc</name>
               <description>Low Frequency Ring Oscillator feature is present</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFRCOSC</name>
+              <name>has_lfrcosc</name>
               <description>Low Frequency RC Oscillator feature is present</description>
               <bitRange>[3:3]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFXOSC</name>
+              <name>has_lfxosc</name>
               <description>Low Frequency Crystal Oscillator feature is present</description>
               <bitRange>[4:4]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_POR</name>
+              <name>has_por</name>
               <description>Power-On-Reset feature is present</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LDO</name>
+              <name>has_ldo</name>
               <description>Low Dropout Regulator feature is present</description>
               <bitRange>[6:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_7</name>
-              <description>Field reserved_31_7</description>
-              <bitRange>[31:7]</bitRange>
-              <access>read-only</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>SiFiveBandgap</name>
-          <description>Bandgap configuration</description>
-          <addressOffset>0x210</addressOffset>
-          <fields>
-            <field>
-              <name>EN</name>
-              <description>Bandgap enable</description>
-              <bitRange>[0:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_7_1</name>
-              <description>Field reserved_7_1</description>
-              <bitRange>[7:1]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>DIS</name>
-              <description>Bandgap disable</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_9</name>
-              <description>Field reserved_15_9</description>
-              <bitRange>[15:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>TRIM</name>
-              <description>Bandgap trim value</description>
-              <bitRange>[19:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_23_20</name>
-              <description>Field reserved_23_20</description>
-              <bitRange>[23:20]</bitRange>
               <access>read-only</access>
             </field>
           </fields>
@@ -620,22 +405,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>lfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfroscen</name>
@@ -663,22 +436,16 @@
               <access>read-write</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>INTERNAL</name>
+                  <name>internal</name>
                   <description>Use internal LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>1</value>
                 </enumeratedValue>
               </enumeratedValues>
-            </field>
-            <field>
-              <name>reserved_30_1</name>
-              <description>Field reserved_30_1</description>
-              <bitRange>[30:1]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfextclk_mux_status</name>
@@ -687,12 +454,12 @@
               <access>read-only</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>SW</name>
+                  <name>sw</name>
                   <description>Use clock source selected by lfextclk_sel</description>
                   <value>1</value>
                 </enumeratedValue>
@@ -703,7 +470,7 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>prci_10008000</name>
+      <name>sifive_fe310_g000_prci_0</name>
       <description>From sifive,fe310-g000,prci,mem peripheral generator</description>
       <baseAddress>0x10008000</baseAddress>
       <addressBlock>
@@ -724,22 +491,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>hfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>hfroscen</name>
@@ -760,12 +515,6 @@
           <description>Crystal Oscillator Configuration and Status</description>
           <addressOffset>0x4</addressOffset>
           <fields>
-            <field>
-              <name>reserved_29_0</name>
-              <description>Field reserved_29_0</description>
-              <bitRange>[29:0]</bitRange>
-              <access>read-only</access>
-            </field>
             <field>
               <name>hfxoscen</name>
               <description>Crystal Oscillator Enable</description>
@@ -792,12 +541,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_3_3</name>
-              <description>Field reserved_3_3</description>
-              <bitRange>[3:3]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pllf</name>
               <description>PLL F Value</description>
               <bitRange>[9:4]</bitRange>
@@ -808,12 +551,6 @@
               <description>PLL Q Value</description>
               <bitRange>[11:10]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_12</name>
-              <description>Field reserved_15_12</description>
-              <bitRange>[15:12]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pllsel</name>
@@ -832,12 +569,6 @@
               <description>PLL Bypass</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_30_19</name>
-              <description>Field reserved_30_19</description>
-              <bitRange>[30:19]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>plllock</name>
@@ -859,12 +590,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_6</name>
-              <description>Field reserved_7_6</description>
-              <bitRange>[7:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>plloutdivby1</name>
               <description>PLL Final Divide By 1</description>
               <bitRange>[13:8]</bitRange>
@@ -884,22 +609,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_5</name>
-              <description>Field reserved_7_5</description>
-              <bitRange>[7:5]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procmon_delay_sel</name>
               <description>Process Monitor Delay Selector</description>
               <bitRange>[12:8]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_13</name>
-              <description>Field reserved_15_13</description>
-              <bitRange>[15:13]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>procmon_en</name>
@@ -908,41 +621,41 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_23_17</name>
-              <description>Field reserved_23_17</description>
-              <bitRange>[23:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procomon_sel</name>
               <description>Process Monitor Select</description>
               <bitRange>[25:24]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_27_26</name>
-              <description>Field reserved_27_26</description>
-              <bitRange>[27:26]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_28_28</name>
-              <description>Field reserved_28_28</description>
-              <bitRange>[28:28]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10015000</name>
+      <name>riscv_clint0_0</name>
+      <description>From riscv,clint0,control peripheral generator</description>
+      <baseAddress>0x2000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_pwm0_0</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10015000</baseAddress>
       <addressBlock>
@@ -953,7 +666,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -962,12 +674,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -988,12 +694,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -1004,12 +704,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -1110,14 +804,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1127,23 +814,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1153,35 +827,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -1191,17 +840,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -1211,17 +853,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1231,17 +866,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1251,18 +879,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>gpio_10012000</name>
+      <name>sifive_gpio0_0</name>
       <description>From sifive,gpio0,control peripheral generator</description>
       <baseAddress>0x10012000</baseAddress>
       <addressBlock>
@@ -1273,110 +895,93 @@
       <registers>
         <register>
           <name>input_val</name>
-          <displayName></displayName>
           <description>Pin value</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>input_en</name>
-          <displayName></displayName>
           <description>Pin input enable</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>output_en</name>
-          <displayName></displayName>
           <description>Pin output enable</description>
           <addressOffset>0x8</addressOffset>
         </register>
         <register>
           <name>output_val</name>
-          <displayName></displayName>
           <description>Output value</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>pue</name>
-          <displayName></displayName>
           <description>Internal pull-up enable</description>
           <addressOffset>0x10</addressOffset>
         </register>
         <register>
           <name>ds</name>
-          <displayName></displayName>
           <description>Pin drive strength</description>
           <addressOffset>0x14</addressOffset>
         </register>
         <register>
           <name>rise_ie</name>
-          <displayName></displayName>
           <description>Rise interrupt enable</description>
           <addressOffset>0x18</addressOffset>
         </register>
         <register>
           <name>rise_ip</name>
-          <displayName></displayName>
           <description>Rise interrupt pending</description>
           <addressOffset>0x1C</addressOffset>
         </register>
         <register>
           <name>fall_ie</name>
-          <displayName></displayName>
           <description>Fall interrupt enable</description>
           <addressOffset>0x20</addressOffset>
         </register>
         <register>
           <name>fall_ip</name>
-          <displayName></displayName>
           <description>Fall interrupt pending</description>
           <addressOffset>0x24</addressOffset>
         </register>
         <register>
           <name>high_ie</name>
-          <displayName></displayName>
           <description>High interrupt enable</description>
           <addressOffset>0x28</addressOffset>
         </register>
         <register>
           <name>high_ip</name>
-          <displayName></displayName>
           <description>High interrupt pending</description>
           <addressOffset>0x2C</addressOffset>
         </register>
         <register>
           <name>low_ie</name>
-          <displayName></displayName>
           <description>Low interrupt enable</description>
           <addressOffset>0x30</addressOffset>
         </register>
         <register>
           <name>low_ip</name>
-          <displayName></displayName>
           <description>Low interrupt pending</description>
           <addressOffset>0x34</addressOffset>
         </register>
         <register>
           <name>iof_en</name>
-          <displayName></displayName>
           <description>I/O function enable</description>
           <addressOffset>0x38</addressOffset>
         </register>
         <register>
           <name>iof_sel</name>
-          <displayName></displayName>
           <description>I/O function select</description>
           <addressOffset>0x3C</addressOffset>
         </register>
         <register>
           <name>out_xor</name>
-          <displayName></displayName>
           <description>Output XOR (invert)</description>
           <addressOffset>0x40</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10013000</name>
+      <name>sifive_uart0_0</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10013000</baseAddress>
       <addressBlock>
@@ -1387,7 +992,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1395,12 +999,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1413,7 +1011,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1422,12 +1019,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1439,7 +1030,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1456,28 +1046,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -1488,28 +1065,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1525,17 +1089,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1551,17 +1108,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1571,18 +1121,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10014000</name>
+      <name>sifive_spi0_0</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10014000</baseAddress>
       <addressBlock>
@@ -1593,7 +1137,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1603,17 +1146,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1629,29 +1165,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1665,7 +1182,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1679,7 +1195,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1689,35 +1204,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1728,28 +1218,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1760,40 +1237,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -1809,17 +1261,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -1829,17 +1274,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -1862,34 +1300,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -1897,12 +1316,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1915,7 +1328,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -1924,12 +1336,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1941,7 +1347,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -1951,17 +1356,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -1971,29 +1369,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -2003,17 +1382,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -2054,12 +1426,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -2074,20 +1440,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -2103,17 +1456,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -2128,12 +1474,6 @@
               <description>Receive watermark pending</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
             </field>
           </fields>
         </register>

--- a/bsp/qemu-sifive-u54/design.svd
+++ b/bsp/qemu-sifive-u54/design.svd
@@ -10,5 +10,17 @@
   <resetValue>0x00000000</resetValue>
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
   </peripherals>
 </device>

--- a/bsp/qemu-sifive-u54mc/design.svd
+++ b/bsp/qemu-sifive-u54mc/design.svd
@@ -11,7 +11,7 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>test_100000</name>
+      <name>sifive_test0_0</name>
       <description>From sifive,test0,control peripheral generator</description>
       <baseAddress>0x100000</baseAddress>
       <addressBlock>
@@ -22,7 +22,6 @@
       <registers>
         <register>
           <name>finisher</name>
-          <displayName>Test Finisher Register</displayName>
           <description>Test finisher register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -40,6 +39,18 @@
             </field>
           </fields>
         </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
       </registers>
     </peripheral>
   </peripherals>

--- a/bsp/sifive-hifive-unleashed/design.svd
+++ b/bsp/sifive-hifive-unleashed/design.svd
@@ -11,7 +11,7 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>cache_controller_2010000</name>
+      <name>sifive_fu540_c000_l2_0</name>
       <description>From sifive,fu540-c000,l2,control peripheral generator</description>
       <baseAddress>0x2010000</baseAddress>
       <addressBlock>
@@ -21,30 +21,30 @@
       </addressBlock>
       <registers>
         <register>
-          <name>Config</name>
+          <name>config</name>
           <description>Information about the Cache Configuration</description>
           <addressOffset>0x0</addressOffset>
           <fields>
             <field>
-              <name>Banks</name>
+              <name>banks</name>
               <description>Number of banks in the cache</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>Ways</name>
+              <name>ways</name>
               <description>Number of ways per bank</description>
               <bitRange>[15:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>lgSets</name>
+              <name>lgsets</name>
               <description>Base-2 logarithm of the sets per bank</description>
               <bitRange>[23:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>lgBlockBytes</name>
+              <name>lgblockbytes</name>
               <description>Base-2 logarithm of the bytes per cache block</description>
               <bitRange>[31:24]</bitRange>
               <access>read-only</access>
@@ -52,24 +52,26 @@
           </fields>
         </register>
         <register>
-          <name>WayEnable</name>
+          <name>wayenable</name>
           <description>The index of the largest way which has been enabled. May only be increased.</description>
           <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Flush64</name>
-          <description>Flush the phsyical address equal to the 64-bit written data from the cache</description>
-          <addressOffset>0x200</addressOffset>
-        </register>
-        <register>
-          <name>Flush32</name>
-          <description>Flush the physical address equal to the 32-bit written data shifted left by 4 from the cache</description>
-          <addressOffset>0x240</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>gpio_10060000</name>
+      <name>riscv_clint0_0</name>
+      <description>From riscv,clint0,control peripheral generator</description>
+      <baseAddress>0x2000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_gpio0_0</name>
       <description>From sifive,gpio0,control peripheral generator</description>
       <baseAddress>0x10060000</baseAddress>
       <addressBlock>
@@ -80,110 +82,93 @@
       <registers>
         <register>
           <name>input_val</name>
-          <displayName></displayName>
           <description>Pin value</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>input_en</name>
-          <displayName></displayName>
           <description>Pin input enable</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>output_en</name>
-          <displayName></displayName>
           <description>Pin output enable</description>
           <addressOffset>0x8</addressOffset>
         </register>
         <register>
           <name>output_val</name>
-          <displayName></displayName>
           <description>Output value</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>pue</name>
-          <displayName></displayName>
           <description>Internal pull-up enable</description>
           <addressOffset>0x10</addressOffset>
         </register>
         <register>
           <name>ds</name>
-          <displayName></displayName>
           <description>Pin drive strength</description>
           <addressOffset>0x14</addressOffset>
         </register>
         <register>
           <name>rise_ie</name>
-          <displayName></displayName>
           <description>Rise interrupt enable</description>
           <addressOffset>0x18</addressOffset>
         </register>
         <register>
           <name>rise_ip</name>
-          <displayName></displayName>
           <description>Rise interrupt pending</description>
           <addressOffset>0x1C</addressOffset>
         </register>
         <register>
           <name>fall_ie</name>
-          <displayName></displayName>
           <description>Fall interrupt enable</description>
           <addressOffset>0x20</addressOffset>
         </register>
         <register>
           <name>fall_ip</name>
-          <displayName></displayName>
           <description>Fall interrupt pending</description>
           <addressOffset>0x24</addressOffset>
         </register>
         <register>
           <name>high_ie</name>
-          <displayName></displayName>
           <description>High interrupt enable</description>
           <addressOffset>0x28</addressOffset>
         </register>
         <register>
           <name>high_ip</name>
-          <displayName></displayName>
           <description>High interrupt pending</description>
           <addressOffset>0x2C</addressOffset>
         </register>
         <register>
           <name>low_ie</name>
-          <displayName></displayName>
           <description>Low interrupt enable</description>
           <addressOffset>0x30</addressOffset>
         </register>
         <register>
           <name>low_ip</name>
-          <displayName></displayName>
           <description>Low interrupt pending</description>
           <addressOffset>0x34</addressOffset>
         </register>
         <register>
           <name>iof_en</name>
-          <displayName></displayName>
           <description>I/O function enable</description>
           <addressOffset>0x38</addressOffset>
         </register>
         <register>
           <name>iof_sel</name>
-          <displayName></displayName>
           <description>I/O function select</description>
           <addressOffset>0x3C</addressOffset>
         </register>
         <register>
           <name>out_xor</name>
-          <displayName></displayName>
           <description>Output XOR (invert)</description>
           <addressOffset>0x40</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>i2c_10030000</name>
+      <name>sifive_i2c0_0</name>
       <description>From sifive,i2c0,control peripheral generator</description>
       <baseAddress>0x10030000</baseAddress>
       <addressBlock>
@@ -194,28 +179,19 @@
       <registers>
         <register>
           <name>prescale_low</name>
-          <displayName>Prescale Low Register</displayName>
           <description>Clock Prescale register lo-byte</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>prescale_high</name>
-          <displayName>Prescale High Register</displayName>
           <description>Clock Prescale register hi-byte</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>control</name>
-          <displayName>Control Register</displayName>
           <description>Control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
-            <field>
-              <name>reserved_lower</name>
-              <description>Reserved lower bits</description>
-              <bitRange>[5:0]</bitRange>
-              <access>read-write</access>
-            </field>
             <field>
               <name>en</name>
               <description>I2C core enable bit</description>
@@ -228,23 +204,15 @@
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>reserved_upper</name>
-              <description>Reserved upper bits</description>
-              <bitRange>[31:8]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>transmit__receive</name>
-          <displayName>Tx and Rx Data Register</displayName>
           <description>Transmit and receive data byte register</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>command__status</name>
-          <displayName>Command and Status Register</displayName>
           <description>Command write and status read register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -296,18 +264,24 @@
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>reserved_31_8</name>
-              <description>Reserved bits</description>
-              <bitRange>[31:8]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10020000</name>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_pwm0_0</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10020000</baseAddress>
       <addressBlock>
@@ -318,7 +292,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -327,12 +300,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -353,12 +320,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -369,12 +330,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -475,14 +430,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -492,23 +440,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -518,35 +453,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -556,17 +466,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -576,17 +479,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -596,17 +492,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -616,18 +505,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10021000</name>
+      <name>sifive_pwm0_1</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10021000</baseAddress>
       <addressBlock>
@@ -638,7 +521,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -647,12 +529,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -673,12 +549,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -689,12 +559,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -795,14 +659,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -812,23 +669,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -838,35 +682,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -876,17 +695,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -896,17 +708,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -916,17 +721,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -936,18 +734,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10010000</name>
+      <name>sifive_uart0_0</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10010000</baseAddress>
       <addressBlock>
@@ -958,7 +750,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -966,12 +757,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -984,7 +769,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -993,12 +777,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1010,7 +788,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1027,28 +804,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -1059,28 +823,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1096,17 +847,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1122,17 +866,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1142,18 +879,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10011000</name>
+      <name>sifive_uart0_1</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10011000</baseAddress>
       <addressBlock>
@@ -1164,7 +895,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1172,12 +902,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1190,7 +914,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1199,12 +922,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1216,7 +933,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1233,28 +949,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -1265,28 +968,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1302,17 +992,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1328,17 +1011,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1348,18 +1024,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10040000</name>
+      <name>sifive_spi0_0</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10040000</baseAddress>
       <addressBlock>
@@ -1370,7 +1040,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1380,17 +1049,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1406,29 +1068,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1442,7 +1085,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1456,7 +1098,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1466,35 +1107,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1505,28 +1121,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1537,40 +1140,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -1586,17 +1164,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -1606,17 +1177,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -1639,34 +1203,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -1674,12 +1219,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1692,7 +1231,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -1701,12 +1239,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1718,7 +1250,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -1728,17 +1259,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -1748,29 +1272,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -1780,17 +1285,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -1831,12 +1329,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -1851,20 +1343,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -1880,17 +1359,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -1906,18 +1378,12 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10041000</name>
+      <name>sifive_spi0_1</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10041000</baseAddress>
       <addressBlock>
@@ -1928,7 +1394,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1938,17 +1403,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1964,29 +1422,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -2000,7 +1439,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -2014,7 +1452,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -2024,35 +1461,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -2063,28 +1475,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -2095,40 +1494,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -2144,17 +1518,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -2164,17 +1531,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -2197,34 +1557,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -2232,12 +1573,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -2250,7 +1585,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -2259,12 +1593,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -2276,7 +1604,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -2286,17 +1613,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -2306,29 +1626,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -2338,17 +1639,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -2389,12 +1683,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -2409,20 +1697,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -2438,17 +1713,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -2464,18 +1732,12 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10050000</name>
+      <name>sifive_spi0_2</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10050000</baseAddress>
       <addressBlock>
@@ -2486,7 +1748,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -2496,17 +1757,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -2522,29 +1776,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -2558,7 +1793,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -2572,7 +1806,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -2582,35 +1815,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -2621,28 +1829,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -2653,40 +1848,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -2702,17 +1872,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -2722,17 +1885,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -2755,34 +1911,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -2790,12 +1927,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -2808,7 +1939,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -2817,12 +1947,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -2834,7 +1958,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -2844,17 +1967,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -2864,29 +1980,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -2896,17 +1993,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -2947,12 +2037,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -2967,20 +2051,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -2996,17 +2067,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -3022,18 +2086,12 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>teststatus_4000</name>
+      <name>sifive_test0_0</name>
       <description>From sifive,test0,control peripheral generator</description>
       <baseAddress>0x4000</baseAddress>
       <addressBlock>
@@ -3044,7 +2102,6 @@
       <registers>
         <register>
           <name>finisher</name>
-          <displayName>Test Finisher Register</displayName>
           <description>Test finisher register</description>
           <addressOffset>0x0</addressOffset>
           <fields>

--- a/bsp/sifive-hifive1-revb/design.svd
+++ b/bsp/sifive-hifive1-revb/design.svd
@@ -11,7 +11,31 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>aon_10000000</name>
+      <name>riscv_clint0_0</name>
+      <description>From riscv,clint0,control peripheral generator</description>
+      <baseAddress>0x2000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_aon0_0</name>
       <description>From sifive,aon0,mem peripheral generator</description>
       <baseAddress>0x10000000</baseAddress>
       <addressBlock>
@@ -112,12 +136,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogrsten</name>
               <description>Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.</description>
               <bitRange>[8:8]</bitRange>
@@ -128,18 +146,6 @@
               <description>Reset counter to zero after match.</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>wdogenalways</name>
@@ -154,58 +160,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -213,11 +171,6 @@
           <name>wdogcount</name>
           <description>Counter Register</description>
           <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>reserved_C</name>
-          <description>Register reserved_C</description>
-          <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>wdogs</name>
@@ -251,100 +204,16 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_8_8</name>
-              <description>Field reserved_8_8</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_9_9</name>
-              <description>Field reserved_9_9</description>
-              <bitRange>[9:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcenalways</name>
               <description>Enable Always - run continuously</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_13_13</name>
-              <description>Field reserved_13_13</description>
-              <bitRange>[13:13]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -362,16 +231,6 @@
           <name>rtcs</name>
           <description>Scaled value of Counter</description>
           <addressOffset>0x50</addressOffset>
-        </register>
-        <register>
-          <name>reserved_58</name>
-          <description>Register reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>reserved_5C</name>
-          <description>Register reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
         </register>
         <register>
           <name>rtccmp0</name>
@@ -479,99 +338,50 @@
           <addressOffset>0x14C</addressOffset>
         </register>
         <register>
-          <name>AONCFG</name>
+          <name>aoncfg</name>
           <description>AON Block Configuration Information</description>
           <addressOffset>0x300</addressOffset>
           <fields>
             <field>
-              <name>HAS_BANDGAP</name>
+              <name>has_bandgap</name>
               <description>Bandgap feature is present</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_BOD</name>
+              <name>has_bod</name>
               <description>Brownout detector feature is present</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFROSC</name>
+              <name>has_lfrosc</name>
               <description>Low Frequency Ring Oscillator feature is present</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFRCOSC</name>
+              <name>has_lfrcosc</name>
               <description>Low Frequency RC Oscillator feature is present</description>
               <bitRange>[3:3]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFXOSC</name>
+              <name>has_lfxosc</name>
               <description>Low Frequency Crystal Oscillator feature is present</description>
               <bitRange>[4:4]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_POR</name>
+              <name>has_por</name>
               <description>Power-On-Reset feature is present</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LDO</name>
+              <name>has_ldo</name>
               <description>Low Dropout Regulator feature is present</description>
               <bitRange>[6:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_7</name>
-              <description>Field reserved_31_7</description>
-              <bitRange>[31:7]</bitRange>
-              <access>read-only</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>SiFiveBandgap</name>
-          <description>Bandgap configuration</description>
-          <addressOffset>0x210</addressOffset>
-          <fields>
-            <field>
-              <name>EN</name>
-              <description>Bandgap enable</description>
-              <bitRange>[0:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_7_1</name>
-              <description>Field reserved_7_1</description>
-              <bitRange>[7:1]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>DIS</name>
-              <description>Bandgap disable</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_9</name>
-              <description>Field reserved_15_9</description>
-              <bitRange>[15:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>TRIM</name>
-              <description>Bandgap trim value</description>
-              <bitRange>[19:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_23_20</name>
-              <description>Field reserved_23_20</description>
-              <bitRange>[23:20]</bitRange>
               <access>read-only</access>
             </field>
           </fields>
@@ -588,22 +398,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>lfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfroscen</name>
@@ -631,22 +429,16 @@
               <access>read-write</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>INTERNAL</name>
+                  <name>internal</name>
                   <description>Use internal LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>1</value>
                 </enumeratedValue>
               </enumeratedValues>
-            </field>
-            <field>
-              <name>reserved_30_1</name>
-              <description>Field reserved_30_1</description>
-              <bitRange>[30:1]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfextclk_mux_status</name>
@@ -655,12 +447,12 @@
               <access>read-only</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>SW</name>
+                  <name>sw</name>
                   <description>Use clock source selected by lfextclk_sel</description>
                   <value>1</value>
                 </enumeratedValue>
@@ -671,7 +463,7 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>prci_10008000</name>
+      <name>sifive_fe310_g000_prci_0</name>
       <description>From sifive,fe310-g000,prci,mem peripheral generator</description>
       <baseAddress>0x10008000</baseAddress>
       <addressBlock>
@@ -692,22 +484,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>hfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>hfroscen</name>
@@ -728,12 +508,6 @@
           <description>Crystal Oscillator Configuration and Status</description>
           <addressOffset>0x4</addressOffset>
           <fields>
-            <field>
-              <name>reserved_29_0</name>
-              <description>Field reserved_29_0</description>
-              <bitRange>[29:0]</bitRange>
-              <access>read-only</access>
-            </field>
             <field>
               <name>hfxoscen</name>
               <description>Crystal Oscillator Enable</description>
@@ -760,12 +534,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_3_3</name>
-              <description>Field reserved_3_3</description>
-              <bitRange>[3:3]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pllf</name>
               <description>PLL F Value</description>
               <bitRange>[9:4]</bitRange>
@@ -776,12 +544,6 @@
               <description>PLL Q Value</description>
               <bitRange>[11:10]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_12</name>
-              <description>Field reserved_15_12</description>
-              <bitRange>[15:12]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pllsel</name>
@@ -800,12 +562,6 @@
               <description>PLL Bypass</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_30_19</name>
-              <description>Field reserved_30_19</description>
-              <bitRange>[30:19]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>plllock</name>
@@ -827,12 +583,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_6</name>
-              <description>Field reserved_7_6</description>
-              <bitRange>[7:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>plloutdivby1</name>
               <description>PLL Final Divide By 1</description>
               <bitRange>[13:8]</bitRange>
@@ -852,22 +602,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_5</name>
-              <description>Field reserved_7_5</description>
-              <bitRange>[7:5]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procmon_delay_sel</name>
               <description>Process Monitor Delay Selector</description>
               <bitRange>[12:8]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_13</name>
-              <description>Field reserved_15_13</description>
-              <bitRange>[15:13]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>procmon_en</name>
@@ -876,41 +614,17 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_23_17</name>
-              <description>Field reserved_23_17</description>
-              <bitRange>[23:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procomon_sel</name>
               <description>Process Monitor Select</description>
               <bitRange>[25:24]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_27_26</name>
-              <description>Field reserved_27_26</description>
-              <bitRange>[27:26]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_28_28</name>
-              <description>Field reserved_28_28</description>
-              <bitRange>[28:28]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>gpio_10012000</name>
+      <name>sifive_gpio0_0</name>
       <description>From sifive,gpio0,control peripheral generator</description>
       <baseAddress>0x10012000</baseAddress>
       <addressBlock>
@@ -921,110 +635,93 @@
       <registers>
         <register>
           <name>input_val</name>
-          <displayName></displayName>
           <description>Pin value</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>input_en</name>
-          <displayName></displayName>
           <description>Pin input enable</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>output_en</name>
-          <displayName></displayName>
           <description>Pin output enable</description>
           <addressOffset>0x8</addressOffset>
         </register>
         <register>
           <name>output_val</name>
-          <displayName></displayName>
           <description>Output value</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>pue</name>
-          <displayName></displayName>
           <description>Internal pull-up enable</description>
           <addressOffset>0x10</addressOffset>
         </register>
         <register>
           <name>ds</name>
-          <displayName></displayName>
           <description>Pin drive strength</description>
           <addressOffset>0x14</addressOffset>
         </register>
         <register>
           <name>rise_ie</name>
-          <displayName></displayName>
           <description>Rise interrupt enable</description>
           <addressOffset>0x18</addressOffset>
         </register>
         <register>
           <name>rise_ip</name>
-          <displayName></displayName>
           <description>Rise interrupt pending</description>
           <addressOffset>0x1C</addressOffset>
         </register>
         <register>
           <name>fall_ie</name>
-          <displayName></displayName>
           <description>Fall interrupt enable</description>
           <addressOffset>0x20</addressOffset>
         </register>
         <register>
           <name>fall_ip</name>
-          <displayName></displayName>
           <description>Fall interrupt pending</description>
           <addressOffset>0x24</addressOffset>
         </register>
         <register>
           <name>high_ie</name>
-          <displayName></displayName>
           <description>High interrupt enable</description>
           <addressOffset>0x28</addressOffset>
         </register>
         <register>
           <name>high_ip</name>
-          <displayName></displayName>
           <description>High interrupt pending</description>
           <addressOffset>0x2C</addressOffset>
         </register>
         <register>
           <name>low_ie</name>
-          <displayName></displayName>
           <description>Low interrupt enable</description>
           <addressOffset>0x30</addressOffset>
         </register>
         <register>
           <name>low_ip</name>
-          <displayName></displayName>
           <description>Low interrupt pending</description>
           <addressOffset>0x34</addressOffset>
         </register>
         <register>
           <name>iof_en</name>
-          <displayName></displayName>
           <description>I/O function enable</description>
           <addressOffset>0x38</addressOffset>
         </register>
         <register>
           <name>iof_sel</name>
-          <displayName></displayName>
           <description>I/O function select</description>
           <addressOffset>0x3C</addressOffset>
         </register>
         <register>
           <name>out_xor</name>
-          <displayName></displayName>
           <description>Output XOR (invert)</description>
           <addressOffset>0x40</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10013000</name>
+      <name>sifive_uart0_0</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10013000</baseAddress>
       <addressBlock>
@@ -1035,7 +732,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1043,12 +739,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1061,7 +751,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1070,12 +759,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1087,7 +770,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1104,28 +786,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -1136,28 +805,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1173,17 +829,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1199,17 +848,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1219,18 +861,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10014000</name>
+      <name>sifive_spi0_0</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10014000</baseAddress>
       <addressBlock>
@@ -1241,7 +877,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1251,17 +886,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1277,29 +905,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1313,7 +922,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1327,7 +935,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1337,35 +944,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1376,28 +958,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1408,40 +977,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -1457,17 +1001,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -1477,17 +1014,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -1510,34 +1040,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -1545,12 +1056,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1563,7 +1068,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -1572,12 +1076,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1589,7 +1087,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -1599,17 +1096,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -1619,29 +1109,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -1651,17 +1122,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -1702,12 +1166,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -1722,20 +1180,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -1751,17 +1196,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -1777,18 +1215,12 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10015000</name>
+      <name>sifive_pwm0_0</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10015000</baseAddress>
       <addressBlock>
@@ -1799,7 +1231,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1808,12 +1239,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -1834,12 +1259,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -1850,12 +1269,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -1956,14 +1369,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1973,23 +1379,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1999,35 +1392,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -2037,17 +1405,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -2057,17 +1418,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -2077,17 +1431,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -2097,18 +1444,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>i2c_10016000</name>
+      <name>sifive_i2c0_0</name>
       <description>From sifive,i2c0,control peripheral generator</description>
       <baseAddress>0x10016000</baseAddress>
       <addressBlock>
@@ -2119,28 +1460,19 @@
       <registers>
         <register>
           <name>prescale_low</name>
-          <displayName>Prescale Low Register</displayName>
           <description>Clock Prescale register lo-byte</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>prescale_high</name>
-          <displayName>Prescale High Register</displayName>
           <description>Clock Prescale register hi-byte</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>control</name>
-          <displayName>Control Register</displayName>
           <description>Control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
-            <field>
-              <name>reserved_lower</name>
-              <description>Reserved lower bits</description>
-              <bitRange>[5:0]</bitRange>
-              <access>read-write</access>
-            </field>
             <field>
               <name>en</name>
               <description>I2C core enable bit</description>
@@ -2153,23 +1485,15 @@
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>reserved_upper</name>
-              <description>Reserved upper bits</description>
-              <bitRange>[31:8]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>transmit__receive</name>
-          <displayName>Tx and Rx Data Register</displayName>
           <description>Transmit and receive data byte register</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>command__status</name>
-          <displayName>Command and Status Register</displayName>
           <description>Command write and status read register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -2221,18 +1545,12 @@
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>reserved_31_8</name>
-              <description>Reserved bits</description>
-              <bitRange>[31:8]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10023000</name>
+      <name>sifive_uart0_1</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10023000</baseAddress>
       <addressBlock>
@@ -2243,7 +1561,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -2251,12 +1568,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -2269,7 +1580,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -2278,12 +1588,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -2295,7 +1599,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -2312,28 +1615,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -2344,28 +1634,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -2381,17 +1658,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -2407,17 +1677,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -2427,18 +1690,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10024000</name>
+      <name>sifive_spi0_1</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10024000</baseAddress>
       <addressBlock>
@@ -2449,7 +1706,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -2459,17 +1715,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -2485,29 +1734,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -2521,7 +1751,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -2535,7 +1764,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -2545,35 +1773,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -2584,28 +1787,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -2616,40 +1806,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -2665,17 +1830,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -2685,17 +1843,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -2718,34 +1869,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -2753,12 +1885,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -2771,7 +1897,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -2780,12 +1905,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -2797,7 +1916,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -2807,17 +1925,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -2827,29 +1938,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -2859,17 +1951,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -2910,12 +1995,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -2930,20 +2009,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -2959,17 +2025,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -2985,18 +2044,12 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10025000</name>
+      <name>sifive_pwm0_1</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10025000</baseAddress>
       <addressBlock>
@@ -3007,7 +2060,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -3016,12 +2068,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -3042,12 +2088,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -3058,12 +2098,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -3164,14 +2198,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -3181,23 +2208,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -3207,35 +2221,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -3245,17 +2234,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -3265,17 +2247,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -3285,17 +2260,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -3305,18 +2273,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10034000</name>
+      <name>sifive_spi0_2</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10034000</baseAddress>
       <addressBlock>
@@ -3327,7 +2289,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -3337,17 +2298,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -3363,29 +2317,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -3399,7 +2334,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -3413,7 +2347,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -3423,35 +2356,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -3462,28 +2370,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -3494,40 +2389,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -3543,17 +2413,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -3563,17 +2426,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -3596,34 +2452,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -3631,12 +2468,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -3649,7 +2480,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -3658,12 +2488,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -3675,7 +2499,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -3685,17 +2508,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -3705,29 +2521,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -3737,17 +2534,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -3788,12 +2578,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -3808,20 +2592,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -3837,17 +2608,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -3863,18 +2627,12 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10035000</name>
+      <name>sifive_pwm0_2</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10035000</baseAddress>
       <addressBlock>
@@ -3885,7 +2643,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -3894,12 +2651,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -3920,12 +2671,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -3936,12 +2681,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -4042,14 +2781,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -4059,23 +2791,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -4085,35 +2804,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -4123,17 +2817,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -4143,17 +2830,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -4163,17 +2843,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -4182,12 +2855,6 @@
               <description>PWM 3 Compare Value</description>
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>

--- a/bsp/sifive-hifive1/design.svd
+++ b/bsp/sifive-hifive1/design.svd
@@ -11,7 +11,7 @@
   <resetMask>0xFFFFFFFF</resetMask>
   <peripherals>
     <peripheral>
-      <name>aon_10000000</name>
+      <name>sifive_aon0_0</name>
       <description>From sifive,aon0,mem peripheral generator</description>
       <baseAddress>0x10000000</baseAddress>
       <addressBlock>
@@ -112,12 +112,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogrsten</name>
               <description>Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.</description>
               <bitRange>[8:8]</bitRange>
@@ -128,18 +122,6 @@
               <description>Reset counter to zero after match.</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>wdogenalways</name>
@@ -154,58 +136,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>wdogip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -213,11 +147,6 @@
           <name>wdogcount</name>
           <description>Counter Register</description>
           <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>reserved_C</name>
-          <description>Register reserved_C</description>
-          <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>wdogs</name>
@@ -251,100 +180,16 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_4</name>
-              <description>Field reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_8_8</name>
-              <description>Field reserved_8_8</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_9_9</name>
-              <description>Field reserved_9_9</description>
-              <bitRange>[9:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_10_10</name>
-              <description>Field reserved_10_10</description>
-              <bitRange>[10:10]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_11_11</name>
-              <description>Field reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcenalways</name>
               <description>Enable Always - run continuously</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_13_13</name>
-              <description>Field reserved_13_13</description>
-              <bitRange>[13:13]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_15_14</name>
-              <description>Field reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_16_16</name>
-              <description>Field reserved_16_16</description>
-              <bitRange>[16:16]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_19_17</name>
-              <description>Field reserved_19_17</description>
-              <bitRange>[19:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_20_20</name>
-              <description>Field reserved_20_20</description>
-              <bitRange>[20:20]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_23_21</name>
-              <description>Field reserved_23_21</description>
-              <bitRange>[23:21]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_24_24</name>
-              <description>Field reserved_24_24</description>
-              <bitRange>[24:24]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_27_25</name>
-              <description>Field reserved_27_25</description>
-              <bitRange>[27:25]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>rtcip0</name>
               <description>Interrupt 0 Pending</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
@@ -362,16 +207,6 @@
           <name>rtcs</name>
           <description>Scaled value of Counter</description>
           <addressOffset>0x50</addressOffset>
-        </register>
-        <register>
-          <name>reserved_58</name>
-          <description>Register reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>reserved_5C</name>
-          <description>Register reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
         </register>
         <register>
           <name>rtccmp0</name>
@@ -479,99 +314,50 @@
           <addressOffset>0x14C</addressOffset>
         </register>
         <register>
-          <name>AONCFG</name>
+          <name>aoncfg</name>
           <description>AON Block Configuration Information</description>
           <addressOffset>0x300</addressOffset>
           <fields>
             <field>
-              <name>HAS_BANDGAP</name>
+              <name>has_bandgap</name>
               <description>Bandgap feature is present</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_BOD</name>
+              <name>has_bod</name>
               <description>Brownout detector feature is present</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFROSC</name>
+              <name>has_lfrosc</name>
               <description>Low Frequency Ring Oscillator feature is present</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFRCOSC</name>
+              <name>has_lfrcosc</name>
               <description>Low Frequency RC Oscillator feature is present</description>
               <bitRange>[3:3]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LFXOSC</name>
+              <name>has_lfxosc</name>
               <description>Low Frequency Crystal Oscillator feature is present</description>
               <bitRange>[4:4]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_POR</name>
+              <name>has_por</name>
               <description>Power-On-Reset feature is present</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>HAS_LDO</name>
+              <name>has_ldo</name>
               <description>Low Dropout Regulator feature is present</description>
               <bitRange>[6:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_7</name>
-              <description>Field reserved_31_7</description>
-              <bitRange>[31:7]</bitRange>
-              <access>read-only</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>SiFiveBandgap</name>
-          <description>Bandgap configuration</description>
-          <addressOffset>0x210</addressOffset>
-          <fields>
-            <field>
-              <name>EN</name>
-              <description>Bandgap enable</description>
-              <bitRange>[0:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_7_1</name>
-              <description>Field reserved_7_1</description>
-              <bitRange>[7:1]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>DIS</name>
-              <description>Bandgap disable</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_9</name>
-              <description>Field reserved_15_9</description>
-              <bitRange>[15:9]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>TRIM</name>
-              <description>Bandgap trim value</description>
-              <bitRange>[19:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_23_20</name>
-              <description>Field reserved_23_20</description>
-              <bitRange>[23:20]</bitRange>
               <access>read-only</access>
             </field>
           </fields>
@@ -588,22 +374,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>lfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfroscen</name>
@@ -631,22 +405,16 @@
               <access>read-write</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>INTERNAL</name>
+                  <name>internal</name>
                   <description>Use internal LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>1</value>
                 </enumeratedValue>
               </enumeratedValues>
-            </field>
-            <field>
-              <name>reserved_30_1</name>
-              <description>Field reserved_30_1</description>
-              <bitRange>[30:1]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>lfextclk_mux_status</name>
@@ -655,12 +423,12 @@
               <access>read-only</access>
               <enumeratedValues>
                 <enumeratedValue>
-                  <name>EXTERNAL</name>
+                  <name>external</name>
                   <description>Use external LF clock source</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
-                  <name>SW</name>
+                  <name>sw</name>
                   <description>Use clock source selected by lfextclk_sel</description>
                   <value>1</value>
                 </enumeratedValue>
@@ -671,7 +439,7 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>prci_10008000</name>
+      <name>sifive_fe310_g000_prci_0</name>
       <description>From sifive,fe310-g000,prci,mem peripheral generator</description>
       <baseAddress>0x10008000</baseAddress>
       <addressBlock>
@@ -692,22 +460,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_15_6</name>
-              <description>Field reserved_15_6</description>
-              <bitRange>[15:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>hfrosctrim</name>
               <description>Ring Oscillator Trim Register</description>
               <bitRange>[20:16]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_29_21</name>
-              <description>Field reserved_29_21</description>
-              <bitRange>[29:21]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>hfroscen</name>
@@ -728,12 +484,6 @@
           <description>Crystal Oscillator Configuration and Status</description>
           <addressOffset>0x4</addressOffset>
           <fields>
-            <field>
-              <name>reserved_29_0</name>
-              <description>Field reserved_29_0</description>
-              <bitRange>[29:0]</bitRange>
-              <access>read-only</access>
-            </field>
             <field>
               <name>hfxoscen</name>
               <description>Crystal Oscillator Enable</description>
@@ -760,12 +510,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_3_3</name>
-              <description>Field reserved_3_3</description>
-              <bitRange>[3:3]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pllf</name>
               <description>PLL F Value</description>
               <bitRange>[9:4]</bitRange>
@@ -776,12 +520,6 @@
               <description>PLL Q Value</description>
               <bitRange>[11:10]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_12</name>
-              <description>Field reserved_15_12</description>
-              <bitRange>[15:12]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pllsel</name>
@@ -800,12 +538,6 @@
               <description>PLL Bypass</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_30_19</name>
-              <description>Field reserved_30_19</description>
-              <bitRange>[30:19]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>plllock</name>
@@ -827,12 +559,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_6</name>
-              <description>Field reserved_7_6</description>
-              <bitRange>[7:6]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>plloutdivby1</name>
               <description>PLL Final Divide By 1</description>
               <bitRange>[13:8]</bitRange>
@@ -852,22 +578,10 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_7_5</name>
-              <description>Field reserved_7_5</description>
-              <bitRange>[7:5]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procmon_delay_sel</name>
               <description>Process Monitor Delay Selector</description>
               <bitRange>[12:8]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_15_13</name>
-              <description>Field reserved_15_13</description>
-              <bitRange>[15:13]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>procmon_en</name>
@@ -876,41 +590,41 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>reserved_23_17</name>
-              <description>Field reserved_23_17</description>
-              <bitRange>[23:17]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>procomon_sel</name>
               <description>Process Monitor Select</description>
               <bitRange>[25:24]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>reserved_27_26</name>
-              <description>Field reserved_27_26</description>
-              <bitRange>[27:26]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_28_28</name>
-              <description>Field reserved_28_28</description>
-              <bitRange>[28:28]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
-              <name>reserved_31_29</name>
-              <description>Field reserved_31_29</description>
-              <bitRange>[31:29]</bitRange>
-              <access>read-only</access>
             </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>pwm_10015000</name>
+      <name>riscv_clint0_0</name>
+      <description>From riscv,clint0,control peripheral generator</description>
+      <baseAddress>0x2000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>riscv_plic0_0</name>
+      <description>From riscv,plic0,control peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>sifive_pwm0_0</name>
       <description>From sifive,pwm0,control peripheral generator</description>
       <baseAddress>0x10015000</baseAddress>
       <addressBlock>
@@ -921,7 +635,6 @@
       <registers>
         <register>
           <name>pwmcfg</name>
-          <displayName>PWM Configuration Register</displayName>
           <description>PWM configuration register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -930,12 +643,6 @@
               <description>PWM Counter scale</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_7_4</name>
-              <description>Field Reserved_7_4</description>
-              <bitRange>[7:4]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmsticky</name>
@@ -956,12 +663,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_11_11</name>
-              <description>Field Reserved_11_11</description>
-              <bitRange>[11:11]</bitRange>
-              <access>read-only</access>
-            </field>
-            <field>
               <name>pwmenalways</name>
               <description>PWM enable always - run continuously</description>
               <bitRange>[12:12]</bitRange>
@@ -972,12 +673,6 @@
               <description>PWM enable one shot - run one cycle</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-only</access>
             </field>
             <field>
               <name>pwmcmp0center</name>
@@ -1078,14 +773,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_4</name>
-          <displayName></displayName>
-          <description>Register Reserved_4</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
           <name>pwmcount</name>
-          <displayName>PWM Count Register</displayName>
           <description>PWM count register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1095,23 +783,10 @@
               <bitRange>[30:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_31</name>
-              <description>Field Reserved_31_31</description>
-              <bitRange>[31:31]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>pwms</name>
-          <displayName>Scaled PWM Count Register</displayName>
           <description>Scaled PWM count register</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1121,35 +796,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_14</name>
-          <displayName></displayName>
-          <description>Register Reserved_14</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_18</name>
-          <displayName></displayName>
-          <description>Register Reserved_18</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
           <name>pwmcmp0</name>
-          <displayName>PWM 0 Compare Register</displayName>
           <description>PWM 0 compare register</description>
           <addressOffset>0x20</addressOffset>
           <fields>
@@ -1159,17 +809,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp1</name>
-          <displayName>PWM 1 Compare Register</displayName>
           <description>PWM 1 compare register</description>
           <addressOffset>0x24</addressOffset>
           <fields>
@@ -1179,17 +822,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp2</name>
-          <displayName>PWM 2 Compare Register</displayName>
           <description>PWM 2 compare register</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1199,17 +835,10 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>pwmcmp3</name>
-          <displayName>PWM 3 Compare Register</displayName>
           <description>PWM 3 compare register</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1219,18 +848,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>gpio_10012000</name>
+      <name>sifive_gpio0_0</name>
       <description>From sifive,gpio0,control peripheral generator</description>
       <baseAddress>0x10012000</baseAddress>
       <addressBlock>
@@ -1241,110 +864,93 @@
       <registers>
         <register>
           <name>input_val</name>
-          <displayName></displayName>
           <description>Pin value</description>
           <addressOffset>0x0</addressOffset>
         </register>
         <register>
           <name>input_en</name>
-          <displayName></displayName>
           <description>Pin input enable</description>
           <addressOffset>0x4</addressOffset>
         </register>
         <register>
           <name>output_en</name>
-          <displayName></displayName>
           <description>Pin output enable</description>
           <addressOffset>0x8</addressOffset>
         </register>
         <register>
           <name>output_val</name>
-          <displayName></displayName>
           <description>Output value</description>
           <addressOffset>0xC</addressOffset>
         </register>
         <register>
           <name>pue</name>
-          <displayName></displayName>
           <description>Internal pull-up enable</description>
           <addressOffset>0x10</addressOffset>
         </register>
         <register>
           <name>ds</name>
-          <displayName></displayName>
           <description>Pin drive strength</description>
           <addressOffset>0x14</addressOffset>
         </register>
         <register>
           <name>rise_ie</name>
-          <displayName></displayName>
           <description>Rise interrupt enable</description>
           <addressOffset>0x18</addressOffset>
         </register>
         <register>
           <name>rise_ip</name>
-          <displayName></displayName>
           <description>Rise interrupt pending</description>
           <addressOffset>0x1C</addressOffset>
         </register>
         <register>
           <name>fall_ie</name>
-          <displayName></displayName>
           <description>Fall interrupt enable</description>
           <addressOffset>0x20</addressOffset>
         </register>
         <register>
           <name>fall_ip</name>
-          <displayName></displayName>
           <description>Fall interrupt pending</description>
           <addressOffset>0x24</addressOffset>
         </register>
         <register>
           <name>high_ie</name>
-          <displayName></displayName>
           <description>High interrupt enable</description>
           <addressOffset>0x28</addressOffset>
         </register>
         <register>
           <name>high_ip</name>
-          <displayName></displayName>
           <description>High interrupt pending</description>
           <addressOffset>0x2C</addressOffset>
         </register>
         <register>
           <name>low_ie</name>
-          <displayName></displayName>
           <description>Low interrupt enable</description>
           <addressOffset>0x30</addressOffset>
         </register>
         <register>
           <name>low_ip</name>
-          <displayName></displayName>
           <description>Low interrupt pending</description>
           <addressOffset>0x34</addressOffset>
         </register>
         <register>
           <name>iof_en</name>
-          <displayName></displayName>
           <description>I/O function enable</description>
           <addressOffset>0x38</addressOffset>
         </register>
         <register>
           <name>iof_sel</name>
-          <displayName></displayName>
           <description>I/O function select</description>
           <addressOffset>0x3C</addressOffset>
         </register>
         <register>
           <name>out_xor</name>
-          <displayName></displayName>
           <description>Output XOR (invert)</description>
           <addressOffset>0x40</addressOffset>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>serial_10013000</name>
+      <name>sifive_uart0_0</name>
       <description>From sifive,uart0,control peripheral generator</description>
       <baseAddress>0x10013000</baseAddress>
       <addressBlock>
@@ -1355,7 +961,6 @@
       <registers>
         <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Transmit data register</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1363,12 +968,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1381,7 +980,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Receive data register</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1390,12 +988,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1407,7 +999,6 @@
         </register>
         <register>
           <name>txctrl</name>
-          <displayName>Transmit Control Register</displayName>
           <description>Transmit control register</description>
           <addressOffset>0x8</addressOffset>
           <fields>
@@ -1424,28 +1015,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_2</name>
-              <description>Field Reserved_15_2</description>
-              <bitRange>[15:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>txcnt</name>
               <description>Transmit watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>rxctrl</name>
-          <displayName>Receive Control Register</displayName>
           <description>Receive control register</description>
           <addressOffset>0xC</addressOffset>
           <fields>
@@ -1456,28 +1034,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_1</name>
-              <description>Field Reserved_15_1</description>
-              <bitRange>[15:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>rxcnt</name>
               <description>Receive watermark level</description>
               <bitRange>[18:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_19</name>
-              <description>Field Reserved_31_19</description>
-              <bitRange>[31:19]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>ie</name>
-          <displayName>UART Interrupt Enable Register</displayName>
           <description>UART interrupt enable</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1493,17 +1058,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>UART Interrupt Pending Register</displayName>
           <description>UART interrupt pending</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1519,17 +1077,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-only</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>div</name>
-          <displayName>Baud Rate Divisor Register</displayName>
           <description>Baud rate divisor</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1539,18 +1090,12 @@
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_16</name>
-              <description>Field Reserved_31_16</description>
-              <bitRange>[31:16]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
       </registers>
     </peripheral>
     <peripheral>
-      <name>spi_10014000</name>
+      <name>sifive_spi0_0</name>
       <description>From sifive,spi0,control peripheral generator</description>
       <baseAddress>0x10014000</baseAddress>
       <addressBlock>
@@ -1561,7 +1106,6 @@
       <registers>
         <register>
           <name>sckdiv</name>
-          <displayName>Serial Clock Divisor Register</displayName>
           <description>Serial clock divisor</description>
           <addressOffset>0x0</addressOffset>
           <fields>
@@ -1571,17 +1115,10 @@
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_12</name>
-              <description>Field Reserved_31_12</description>
-              <bitRange>[31:12]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sckmode</name>
-          <displayName>Serial Clock Mode Register</displayName>
           <description>Serial clock mode</description>
           <addressOffset>0x4</addressOffset>
           <fields>
@@ -1597,29 +1134,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_8</name>
-          <displayName></displayName>
-          <description>Register Reserved_8</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_C</name>
-          <displayName></displayName>
-          <description>Register Reserved_C</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
           <name>csid</name>
-          <displayName>Chip Select ID Register</displayName>
           <description>Chip select ID</description>
           <addressOffset>0x10</addressOffset>
           <fields>
@@ -1633,7 +1151,6 @@
         </register>
         <register>
           <name>csdef</name>
-          <displayName>Chip Select Default Register</displayName>
           <description>Chip select default</description>
           <addressOffset>0x14</addressOffset>
           <fields>
@@ -1647,7 +1164,6 @@
         </register>
         <register>
           <name>csmode</name>
-          <displayName>Chip Select Mode Register</displayName>
           <description>Chip select mode</description>
           <addressOffset>0x18</addressOffset>
           <fields>
@@ -1657,35 +1173,10 @@
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_1C</name>
-          <displayName></displayName>
-          <description>Register Reserved_1C</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_20</name>
-          <displayName></displayName>
-          <description>Register Reserved_20</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_24</name>
-          <displayName></displayName>
-          <description>Register Reserved_24</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
           <name>delay0</name>
-          <displayName>Delay Control Register 0</displayName>
           <description>Delay control 0</description>
           <addressOffset>0x28</addressOffset>
           <fields>
@@ -1696,28 +1187,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>sckcs</name>
               <description>SCK to CS Delay</description>
               <bitRange>[23:16]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
         </register>
         <register>
           <name>delay1</name>
-          <displayName>Delay Control Register 1</displayName>
           <description>Delay control 1</description>
           <addressOffset>0x2C</addressOffset>
           <fields>
@@ -1728,40 +1206,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_8</name>
-              <description>Field Reserved_15_8</description>
-              <bitRange>[15:8]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>interxfr</name>
               <description>Maximum interframe delay</description>
               <bitRange>[23:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_24</name>
-              <description>Field Reserved_31_24</description>
-              <bitRange>[31:24]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_30</name>
-          <displayName></displayName>
-          <description>Register Reserved_30</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_34</name>
-          <displayName></displayName>
-          <description>Register Reserved_34</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
           <name>extradel</name>
-          <displayName>SPI extra delay Register</displayName>
           <description>SPI extra sampling delay to increase the SPI frequency</description>
           <addressOffset>0x38</addressOffset>
           <fields>
@@ -1777,17 +1230,10 @@
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_17</name>
-              <description>Field Reserved_31_17</description>
-              <bitRange>[31:17]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>sampledel</name>
-          <displayName>Slave to SPI delay stages Register</displayName>
           <description>Number of delay stages from slave to the SPI controller</description>
           <addressOffset>0x3C</addressOffset>
           <fields>
@@ -1797,17 +1243,10 @@
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_5</name>
-              <description>Field Reserved_31_5</description>
-              <bitRange>[31:5]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>fmt</name>
-          <displayName>Frame Format Register</displayName>
           <description>Frame format</description>
           <addressOffset>0x40</addressOffset>
           <fields>
@@ -1830,34 +1269,15 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_4</name>
-              <description>Field Reserved_15_4</description>
-              <bitRange>[15:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>len</name>
               <description>Number of bits per frame</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_20</name>
-              <description>Field Reserved_31_20</description>
-              <bitRange>[31:20]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_44</name>
-          <displayName></displayName>
-          <description>Register Reserved_44</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
           <name>txdata</name>
-          <displayName>Transmit Data Register</displayName>
           <description>Tx FIFO Data</description>
           <addressOffset>0x48</addressOffset>
           <fields>
@@ -1865,12 +1285,6 @@
               <name>data</name>
               <description>Transmit data</description>
               <bitRange>[7:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -1883,7 +1297,6 @@
         </register>
         <register>
           <name>rxdata</name>
-          <displayName>Receive Data Register</displayName>
           <description>Rx FIFO data</description>
           <addressOffset>0x4C</addressOffset>
           <fields>
@@ -1892,12 +1305,6 @@
               <description>Received data</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_30_8</name>
-              <description>Field Reserved_30_8</description>
-              <bitRange>[30:8]</bitRange>
-              <access>read-write</access>
             </field>
             <field>
               <name>empty</name>
@@ -1909,7 +1316,6 @@
         </register>
         <register>
           <name>txmark</name>
-          <displayName>Transmit Watermark Register</displayName>
           <description>Tx FIFO watermark</description>
           <addressOffset>0x50</addressOffset>
           <fields>
@@ -1919,17 +1325,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>rxmark</name>
-          <displayName>Receive Watermark Register</displayName>
           <description>Rx FIFO watermark</description>
           <addressOffset>0x54</addressOffset>
           <fields>
@@ -1939,29 +1338,10 @@
               <bitRange>[2:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_3</name>
-              <description>Field Reserved_31_3</description>
-              <bitRange>[31:3]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
-          <name>Reserved_58</name>
-          <displayName></displayName>
-          <description>Register Reserved_58</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_5C</name>
-          <displayName></displayName>
-          <description>Register Reserved_5C</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
           <name>fctrl</name>
-          <displayName>SPI Flash Interface Control Register</displayName>
           <description>SPI flash interface control</description>
           <addressOffset>0x60</addressOffset>
           <fields>
@@ -1971,17 +1351,10 @@
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_1</name>
-              <description>Field Reserved_31_1</description>
-              <bitRange>[31:1]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ffmt</name>
-          <displayName>SPI Flash Instruction Format Register</displayName>
           <description>SPI flash instruction format</description>
           <addressOffset>0x64</addressOffset>
           <fields>
@@ -2022,12 +1395,6 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>Reserved_15_14</name>
-              <description>Field Reserved_15_14</description>
-              <bitRange>[15:14]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>cmd_code</name>
               <description>Value of command byte</description>
               <bitRange>[23:16]</bitRange>
@@ -2042,20 +1409,7 @@
           </fields>
         </register>
         <register>
-          <name>Reserved_68</name>
-          <displayName></displayName>
-          <description>Register Reserved_68</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>Reserved_6C</name>
-          <displayName></displayName>
-          <description>Register Reserved_6C</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
           <name>ie</name>
-          <displayName>SPI Interrupt Enable Register</displayName>
           <description>SPI interrupt enable</description>
           <addressOffset>0x70</addressOffset>
           <fields>
@@ -2071,17 +1425,10 @@
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
-            </field>
           </fields>
         </register>
         <register>
           <name>ip</name>
-          <displayName>SPI Watermark Interrupt Pending Register</displayName>
           <description>SPI interrupt pending</description>
           <addressOffset>0x74</addressOffset>
           <fields>
@@ -2096,12 +1443,6 @@
               <description>Receive watermark pending</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
-            </field>
-            <field>
-              <name>Reserved_31_2</name>
-              <description>Field Reserved_31_2</description>
-              <bitRange>[31:2]</bitRange>
-              <access>read-write</access>
             </field>
           </fields>
         </register>

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -30,7 +30,7 @@
         "source": "git@github.com:sifive/ldscript-generator.git"
     },
     {
-        "commit": "6e3c6ef8087dce085434df15e9e6ebccbbeb2050",
+        "commit": "85468a85e61270ff646eec2b02f0dfdea5c9b776",
         "name": "cmsis-svd-generator",
         "source": "git@github.com:sifive/cmsis-svd-generator.git"
     },


### PR DESCRIPTION
- All lower case names
- Leave out the displayName
- Leave out reserved registers and fields
- Use freedom-e-sdk naming standard for peripheral names
- Add empty register files for interrupt controllers (first step)
