### PR TITLE
Update website URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,4 +306,4 @@ Run `make help` for more commands.
 
 Documentation, Forums, and much more available at
 
-[dev.sifive.com](https://dev.sifive.com)
+[www.sifive.com](https://www.sifive.com)


### PR DESCRIPTION
I noticed that this is pointing at our old developers website. Although there's a redirect from the old domain to the new one, it's best to update this to point to the new one.