### PR TITLE
Add FREEDOM_E_SDK_VENV_PATH to move virtualenv

### DIFF
--- a/bsp/update-targets.sh
+++ b/bsp/update-targets.sh
@@ -78,6 +78,10 @@ fi
 
 OVERLAY_GENERATOR=../scripts/devicetree-overlay-generator/generate_overlay.py
 
+if [ "${FREEDOM_E_SDK_VENV_PATH}" == "" ]; then
+    FREEDOM_E_SDK_VENV_PATH="../venv"
+fi
+
 DTC=dtc
 MEE_HEADER_GENERATOR=freedom-metal_header-generator
 LDSCRIPT_GENERATOR=../scripts/ldscript-generator/generate_ldscript.py
@@ -110,7 +114,7 @@ update_target() {
     # Generate overlay
     if [ $NO_FIXUP -ne 1 ]; then
         echo "Generating overlay $TARGET/$DESIGN_DTS_FILENAME"
-        . ../venv/bin/activate && $OVERLAY_GENERATOR --type $TARGET_TYPE --output $TARGET/$DESIGN_DTS_FILENAME --rename-include $CORE_DTS_FILENAME $TARGET/$CORE_DTS_FILENAME
+        . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $OVERLAY_GENERATOR --type $TARGET_TYPE --output $TARGET/$DESIGN_DTS_FILENAME --rename-include $CORE_DTS_FILENAME $TARGET/$CORE_DTS_FILENAME
     fi
 
     # Compile temporary .dtb
@@ -118,22 +122,22 @@ update_target() {
 
     # Produce parameterized files
     pushd $TARGET && $MEE_HEADER_GENERATOR -d $DTB_FILENAME -o $HEADER_FILENAME || warn "Failed to produce $TARGET/$HEADER_FILENAME" && popd
-    . ../venv/bin/activate && $LDSCRIPT_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$LDS_DEFAULT_FILENAME || warn "Failed to produce $TARGET/$LDS_DEFAULT_FILENAME"
-    . ../venv/bin/activate && $LDSCRIPT_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$LDS_RAMRODATA_FILENAME --ramrodata || warn "Failed to produce $TARGET/$LDS_RAMRODATA_FILENAME"
-    . ../venv/bin/activate && $LDSCRIPT_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$LDS_SCRATCHPAD_FILENAME --scratchpad || warn "Failed to produce $TARGET/$LDS_SCRATCHPAD_FILENAME"
-    . ../venv/bin/activate && $SETTINGS_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -t $TARGET_TYPE -o $TARGET/$SETTINGS_FILENAME || warn "Failed to produce $TARGET/$SETTINGS_FILENAME"
+    . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $LDSCRIPT_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$LDS_DEFAULT_FILENAME || warn "Failed to produce $TARGET/$LDS_DEFAULT_FILENAME"
+    . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $LDSCRIPT_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$LDS_RAMRODATA_FILENAME --ramrodata || warn "Failed to produce $TARGET/$LDS_RAMRODATA_FILENAME"
+    . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $LDSCRIPT_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$LDS_SCRATCHPAD_FILENAME --scratchpad || warn "Failed to produce $TARGET/$LDS_SCRATCHPAD_FILENAME"
+    . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $SETTINGS_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -t $TARGET_TYPE -o $TARGET/$SETTINGS_FILENAME || warn "Failed to produce $TARGET/$SETTINGS_FILENAME"
     pushd  $TARGET && $BARE_HEADER_GENERATOR -d $DTB_FILENAME -o $BARE_HEADER_FILENAME || warn "Failed to produce $TARGET/$BARE_HEADER_FILENAME" && popd
-    . ../venv/bin/activate && $CMSIS_SVD_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$CMSIS_SVD_FILENAME || warn "Failed to produce $TARGET/$CMSIS_SVD_FILENAME"
+    . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $CMSIS_SVD_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -o $TARGET/$CMSIS_SVD_FILENAME || warn "Failed to produce $TARGET/$CMSIS_SVD_FILENAME"
 
     if [[ "$TARGET_TYPE" =~ "arty" || "$TARGET_TYPE" =~ "vc707" || "$TARGET_TYPE" =~ "hifive" ]] ; then
         if [ `grep -c "jlink" $TARGET/$SETTINGS_FILENAME` -ne 1 ] ; then
             echo "generating $OPENOCDCFG_FILENAME"
-            . ../venv/bin/activate && $OPENOCDCFG_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -b $TARGET_TYPE -o $TARGET/$OPENOCDCFG_FILENAME || warn "Failed to produce $TARGET/$OPENOCDCFG_FILENAME"
+            . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $OPENOCDCFG_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -b $TARGET_TYPE -o $TARGET/$OPENOCDCFG_FILENAME || warn "Failed to produce $TARGET/$OPENOCDCFG_FILENAME"
         fi
     fi
     if [[ "$TARGET_TYPE" =~ "arty" ]] ; then
         echo "generating $OPENOCDCFG_CJTAG_FILENAME"
-        . ../venv/bin/activate && $OPENOCDCFG_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -p cjtag -b $TARGET_TYPE -o $TARGET/$OPENOCDCFG_CJTAG_FILENAME || warn "Failed to produce $TARGET/$OPENOCDCFG_CJTAG_FILENAME"
+        . ${FREEDOM_E_SDK_VENV_PATH}/bin/activate && $OPENOCDCFG_GENERATOR -d $TARGET/$DESIGN_DTS_FILENAME -p cjtag -b $TARGET_TYPE -o $TARGET/$OPENOCDCFG_CJTAG_FILENAME || warn "Failed to produce $TARGET/$OPENOCDCFG_CJTAG_FILENAME"
     fi
 
     # Remove temporary .dtb

--- a/scripts/libmetal.mk
+++ b/scripts/libmetal.mk
@@ -29,27 +29,27 @@ SETTINGS_GENERATOR = scripts/esdk-settings-generator/generate_settings.py
 
 $(BSP_DIR)/design.dts: $(BSP_DIR)/core.dts $(OVERLAY_GENERATOR)
 	$(MAKE) -f scripts/virtualenv.mk virtualenv
-	. venv/bin/activate && $(OVERLAY_GENERATOR) --type $(TARGET) --output $@ --rename-include $(notdir $<) $<
+	. $(FREEDOM_E_SDK_VENV_PATH)/bin/activate && $(OVERLAY_GENERATOR) --type $(TARGET) --output $@ --rename-include $(notdir $<) $<
 
 $(BSP_DIR)/metal.default.lds: $(BSP_DIR)/design.dts $(LDSCRIPT_GENERATOR)
 	$(MAKE) -f scripts/virtualenv.mk virtualenv
-	. venv/bin/activate && $(LDSCRIPT_GENERATOR) -d $< -o $@
+	. $(FREEDOM_E_SDK_VENV_PATH)/bin/activate && $(LDSCRIPT_GENERATOR) -d $< -o $@
 
 $(BSP_DIR)/metal.ramrodata.lds: $(BSP_DIR)/design.dts $(LDSCRIPT_GENERATOR)
 	$(MAKE) -f scripts/virtualenv.mk virtualenv
-	. venv/bin/activate && $(LDSCRIPT_GENERATOR) -d $< -o $@ --ramrodata
+	. $(FREEDOM_E_SDK_VENV_PATH)/bin/activate && $(LDSCRIPT_GENERATOR) -d $< -o $@ --ramrodata
 
 $(BSP_DIR)/metal.scratchpad.lds: $(BSP_DIR)/design.dts $(LDSCRIPT_GENERATOR)
 	$(MAKE) -f scripts/virtualenv.mk virtualenv
-	. venv/bin/activate && $(LDSCRIPT_GENERATOR) -d $< -o $@ --scratchpad
+	. $(FREEDOM_E_SDK_VENV_PATH)/bin/activate && $(LDSCRIPT_GENERATOR) -d $< -o $@ --scratchpad
 
 $(BSP_DIR)/design.svd: $(BSP_DIR)/design.dts $(CMSIS_SVD_GENERATOR)
 	$(MAKE) -f scripts/virtualenv.mk virtualenv
-	. venv/bin/activate && $(CMSIS_SVD_GENERATOR) -d $< -o $@
+	. $(FREEDOM_E_SDK_VENV_PATH)/bin/activate && $(CMSIS_SVD_GENERATOR) -d $< -o $@
 
 $(BSP_DIR)/settings.mk: $(BSP_DIR)/design.dts $(SETTINGS_GENERATOR)
 	$(MAKE) -f scripts/virtualenv.mk virtualenv
-	. venv/bin/activate && $(SETTINGS_GENERATOR) -d $< -o $@ -t $(TARGET)
+	. $(FREEDOM_E_SDK_VENV_PATH)/bin/activate && $(SETTINGS_GENERATOR) -d $< -o $@ -t $(TARGET)
 
 ifeq ($(findstring spike,$(TARGET)),spike)
 $(BSP_DIR)/spike_options.sh:

--- a/scripts/virtualenv.mk
+++ b/scripts/virtualenv.mk
@@ -1,6 +1,11 @@
 
+# By default, the Python virtualenv is created in the `venv` folder at the root
+# of freedom-e-sdk. If you want your virtualenv to be placed somewhere else,
+# set the FREEDOM_E_SDK_VENV_PATH environment variable.
+FREEDOM_E_SDK_VENV_PATH ?= venv
+
 .PHONY: virtualenv
-virtualenv: venv/.stamp
+virtualenv: $(FREEDOM_E_SDK_VENV_PATH)/.stamp
 
 # Just in case the cached dependencies fail, users can install Python packages
 # from the Python Package Index by running `make virtualenv-from-pypi`
@@ -8,17 +13,17 @@ virtualenv: venv/.stamp
 .PHONY: virtualenv-from-pypi
 
 # invoke python3 pip in order to bypass 127 character limit in shebang
-virtualenv-from-pypi: venv/bin/activate requirements.txt
-	. $< && venv/bin/python3 venv/bin/pip install --upgrade pip
-	. $< && venv/bin/python3 venv/bin/pip install -r requirements.txt
+virtualenv-from-pypi: $(FREEDOM_E_SDK_VENV_PATH)/bin/activate requirements.txt
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install --upgrade pip
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install -r requirements.txt
 
-venv/.stamp: venv/bin/activate requirements.txt
-	. $< && venv/bin/python3 venv/bin/pip install --no-index --find-links pip-cache --upgrade pip
-	. $< && venv/bin/python3 venv/bin/pip install --no-index --find-links pip-cache -r requirements.txt
+$(FREEDOM_E_SDK_VENV_PATH)/.stamp: $(FREEDOM_E_SDK_VENV_PATH)/bin/activate requirements.txt
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install --no-index --find-links pip-cache --upgrade pip
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install --no-index --find-links pip-cache -r requirements.txt
 	touch $@
 
-venv/bin/activate:
-	python3 -m venv venv
+$(FREEDOM_E_SDK_VENV_PATH)/bin/activate:
+	python3 -m venv $(FREEDOM_E_SDK_VENV_PATH)
 
 # The pip-cache directory holds a cache of all the Python package dependencies, being careful
 # that all are platform-indepentent.
@@ -39,5 +44,5 @@ clean-pip-cache:
 
 .PHONY: clean-virtualenv
 clean-virtualenv:
-	-rm -rf venv
+	-rm -rf $(FREEDOM_E_SDK_VENV_PATH)
 


### PR DESCRIPTION
The FREEDOM_E_SDK_VENV_PATH environment variable allows the path to the virtualenv to be moved at will while defaulting to the same directory an freedom-e-sdk.

This is added to facilitate running Freedom E SDK in wake, where multiple BSPs might be created at the same time. By using a different virtualenv for each BSP creation job, we can eliminate contention over the virtualenv directory.