### PR TITLE
Bump ldscript generator for various fixes

### DIFF
--- a/bsp/freedom-e310-arty/metal.default.lds
+++ b/bsp/freedom-e310-arty/metal.default.lds
@@ -22,6 +22,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -169,7 +170,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -181,6 +182,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -192,7 +198,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -204,7 +210,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -212,7 +218,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -238,13 +244,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/freedom-e310-arty/metal.freertos.lds
+++ b/bsp/freedom-e310-arty/metal.freertos.lds
@@ -25,6 +25,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -180,7 +181,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -192,6 +193,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -204,7 +210,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -216,7 +222,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -224,7 +230,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -259,13 +265,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/freedom-e310-arty/metal.ramrodata.lds
+++ b/bsp/freedom-e310-arty/metal.ramrodata.lds
@@ -26,6 +26,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -161,7 +162,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -173,6 +174,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -196,7 +202,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -208,7 +214,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -216,7 +222,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -242,13 +248,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/freedom-e310-arty/metal.scratchpad.lds
+++ b/bsp/freedom-e310-arty/metal.scratchpad.lds
@@ -23,6 +23,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -170,7 +171,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>ram :rom
+    } >itim AT>ram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -182,6 +183,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -193,7 +199,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>ram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>ram :tls :ram_init
@@ -205,7 +211,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -213,7 +219,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -239,13 +245,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-e31/metal.default.lds
+++ b/bsp/qemu-sifive-e31/metal.default.lds
@@ -21,6 +21,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -168,7 +169,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -180,6 +181,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -191,7 +197,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -203,7 +209,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -211,7 +217,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -237,13 +243,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-e31/metal.freertos.lds
+++ b/bsp/qemu-sifive-e31/metal.freertos.lds
@@ -24,6 +24,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -179,7 +180,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -191,6 +192,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -203,7 +209,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -215,7 +221,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -223,7 +229,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -258,13 +264,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-e31/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-e31/metal.ramrodata.lds
@@ -25,6 +25,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -160,7 +161,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -172,6 +173,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -195,7 +201,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -207,7 +213,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -215,7 +221,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -241,13 +247,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-e31/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-e31/metal.scratchpad.lds
@@ -22,6 +22,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -169,7 +170,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>ram :rom
+    } >ram AT>ram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -181,6 +182,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -192,7 +198,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>ram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>ram :tls :ram_init
@@ -204,7 +210,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -212,7 +218,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -238,13 +244,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-s51/metal.default.lds
+++ b/bsp/qemu-sifive-s51/metal.default.lds
@@ -21,6 +21,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -168,7 +169,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -180,6 +181,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -191,7 +197,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -203,7 +209,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -211,7 +217,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -237,13 +243,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-s51/metal.freertos.lds
+++ b/bsp/qemu-sifive-s51/metal.freertos.lds
@@ -24,6 +24,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -179,7 +180,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -191,6 +192,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -203,7 +209,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -215,7 +221,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -223,7 +229,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -258,13 +264,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-s51/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-s51/metal.ramrodata.lds
@@ -25,6 +25,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -160,7 +161,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -172,6 +173,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -195,7 +201,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -207,7 +213,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -215,7 +221,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -241,13 +247,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-s51/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-s51/metal.scratchpad.lds
@@ -22,6 +22,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -169,7 +170,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>ram :rom
+    } >ram AT>ram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -181,6 +182,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -192,7 +198,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>ram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>ram :tls :ram_init
@@ -204,7 +210,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -212,7 +218,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -238,13 +244,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/qemu-sifive-u54/metal.default.lds
+++ b/bsp/qemu-sifive-u54/metal.default.lds
@@ -20,6 +20,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -167,7 +168,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -179,6 +180,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -190,7 +196,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -202,7 +208,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -210,7 +216,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -236,13 +242,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54/metal.freertos.lds
+++ b/bsp/qemu-sifive-u54/metal.freertos.lds
@@ -23,6 +23,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -178,7 +179,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -190,6 +191,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -202,7 +208,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -214,7 +220,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -222,7 +228,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -257,13 +263,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-u54/metal.ramrodata.lds
@@ -24,6 +24,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -159,7 +160,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -171,6 +172,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -194,7 +200,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -206,7 +212,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -214,7 +220,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -240,13 +246,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-u54/metal.scratchpad.lds
@@ -21,6 +21,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -168,7 +169,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -180,6 +181,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -191,7 +197,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -203,7 +209,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -211,7 +217,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -237,13 +243,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54mc/metal.default.lds
+++ b/bsp/qemu-sifive-u54mc/metal.default.lds
@@ -20,6 +20,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -167,7 +168,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -179,6 +180,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -190,7 +196,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -202,7 +208,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -210,7 +216,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -239,13 +245,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54mc/metal.freertos.lds
+++ b/bsp/qemu-sifive-u54mc/metal.freertos.lds
@@ -23,6 +23,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -178,7 +179,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -190,6 +191,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -202,7 +208,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -214,7 +220,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -222,7 +228,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -260,13 +266,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54mc/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-u54mc/metal.ramrodata.lds
@@ -24,6 +24,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -159,7 +160,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -171,6 +172,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -194,7 +200,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -206,7 +212,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -214,7 +220,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -243,13 +249,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/qemu-sifive-u54mc/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-u54mc/metal.scratchpad.lds
@@ -21,6 +21,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -168,7 +169,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -180,6 +181,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -191,7 +197,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -203,7 +209,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -211,7 +217,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -240,13 +246,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/sifive-hifive-unleashed/metal.default.lds
+++ b/bsp/sifive-hifive-unleashed/metal.default.lds
@@ -22,6 +22,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -169,7 +170,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -181,6 +182,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -192,7 +198,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -204,7 +210,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -212,7 +218,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -242,13 +248,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive-unleashed/metal.freertos.lds
+++ b/bsp/sifive-hifive-unleashed/metal.freertos.lds
@@ -25,6 +25,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -180,7 +181,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -192,6 +193,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -204,7 +210,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -216,7 +222,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -224,7 +230,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -263,13 +269,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive-unleashed/metal.ramrodata.lds
+++ b/bsp/sifive-hifive-unleashed/metal.ramrodata.lds
@@ -26,6 +26,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -163,7 +164,7 @@ SECTIONS
         *(.text .text.*)
         *(.gnu.linkonce.t.*)
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -175,6 +176,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -198,7 +204,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -210,7 +216,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -218,7 +224,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -248,13 +254,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive-unleashed/metal.scratchpad.lds
+++ b/bsp/sifive-hifive-unleashed/metal.scratchpad.lds
@@ -23,6 +23,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -170,7 +171,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>ram :rom
+    } >itim AT>ram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -182,6 +183,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -193,7 +199,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>ram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>ram :tls :ram_init
@@ -205,7 +211,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -213,7 +219,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -243,13 +249,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1-revb/metal.default.lds
+++ b/bsp/sifive-hifive1-revb/metal.default.lds
@@ -22,6 +22,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -169,7 +170,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -181,6 +182,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -192,7 +198,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -204,7 +210,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -212,7 +218,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -238,13 +244,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1-revb/metal.freertos.lds
+++ b/bsp/sifive-hifive1-revb/metal.freertos.lds
@@ -25,6 +25,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -180,7 +181,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -192,6 +193,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -204,7 +210,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -216,7 +222,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -224,7 +230,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -259,13 +265,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1-revb/metal.ramrodata.lds
+++ b/bsp/sifive-hifive1-revb/metal.ramrodata.lds
@@ -26,6 +26,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -161,7 +162,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>rom :rom
+    } >itim AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -173,6 +174,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -196,7 +202,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -208,7 +214,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -216,7 +222,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -242,13 +248,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1-revb/metal.scratchpad.lds
+++ b/bsp/sifive-hifive1-revb/metal.scratchpad.lds
@@ -23,6 +23,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -170,7 +171,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >itim AT>ram :rom
+    } >itim AT>ram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -182,6 +183,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -193,7 +199,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>ram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>ram :tls :ram_init
@@ -205,7 +211,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -213,7 +219,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -239,13 +245,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1/metal.default.lds
+++ b/bsp/sifive-hifive1/metal.default.lds
@@ -21,6 +21,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -168,7 +169,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -180,6 +181,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -191,7 +197,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -203,7 +209,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -211,7 +217,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -237,13 +243,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1/metal.freertos.lds
+++ b/bsp/sifive-hifive1/metal.freertos.lds
@@ -24,6 +24,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -179,7 +180,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -191,6 +192,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -203,7 +209,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -215,7 +221,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -223,7 +229,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -258,13 +264,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1/metal.ramrodata.lds
+++ b/bsp/sifive-hifive1/metal.ramrodata.lds
@@ -25,6 +25,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -160,7 +161,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>rom :rom
+    } >ram AT>rom :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -172,6 +173,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -195,7 +201,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >ram AT>rom :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>rom :tls :ram_init
@@ -207,7 +213,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -215,7 +221,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -241,13 +247,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/sifive-hifive1/metal.scratchpad.lds
+++ b/bsp/sifive-hifive1/metal.scratchpad.lds
@@ -22,6 +22,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -169,7 +170,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >ram AT>ram :rom
+    } >ram AT>ram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -181,6 +182,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -192,7 +198,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >ram AT>ram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >ram AT>ram :tls :ram_init
@@ -204,7 +210,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -212,7 +218,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >ram :ram
 
@@ -238,13 +244,14 @@ SECTIONS
     } >ram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >ram :ram
 }

--- a/bsp/spike/metal.default.lds
+++ b/bsp/spike/metal.default.lds
@@ -20,6 +20,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -167,7 +168,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -179,6 +180,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -190,7 +196,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -202,7 +208,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -210,7 +216,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -236,13 +242,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/spike/metal.freertos.lds
+++ b/bsp/spike/metal.freertos.lds
@@ -23,6 +23,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -178,7 +179,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -190,6 +191,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -202,7 +208,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -214,7 +220,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -222,7 +228,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -257,13 +263,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/spike/metal.ramrodata.lds
+++ b/bsp/spike/metal.ramrodata.lds
@@ -24,6 +24,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -159,7 +160,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -171,6 +172,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -194,7 +200,7 @@ SECTIONS
         *(.gnu.linkonce.r.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -206,7 +212,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -214,7 +220,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -240,13 +246,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/bsp/spike/metal.scratchpad.lds
+++ b/bsp/spike/metal.scratchpad.lds
@@ -21,6 +21,7 @@ PHDRS
     ram_init PT_LOAD;
     tls PT_TLS;
     ram PT_LOAD;
+    itim_init PT_LOAD;
 }
 
 SECTIONS
@@ -168,7 +169,7 @@ SECTIONS
 
     .itim : ALIGN(8) {
         *(.itim .itim.*)
-    } >testram AT>testram :rom
+    } >testram AT>testram :itim_init
 
     PROVIDE( metal_segment_itim_source_start = LOADADDR(.itim) );
     PROVIDE( metal_segment_itim_target_start = ADDR(.itim) );
@@ -180,6 +181,11 @@ SECTIONS
      * memory into a read-write-capable memory such as data tightly-integrated
      * memory (DTIM) or another main memory, as well as the BSS, stack, and
      * heap.
+     *
+     * You might notice that .data, .tdata, .tbss, .tbss_space, and .bss all
+     * have an apparently unnecessary ALIGN at their top. This is because
+     * the implementation of _start in Freedom Metal libgloss depends on the
+     * ADDR and LOADADDR being 8-byte aligned.
      */
 
     .data : ALIGN(8) {
@@ -191,7 +197,7 @@ SECTIONS
         *(.gnu.linkonce.s.*)
     } >testram AT>testram :ram_init
 
-    .tdata : {
+    .tdata : ALIGN(8) {
         PROVIDE( __tls_base = . );
 	*(.tdata .tdata.* .gnu.linkonce.td.*)
     } >testram AT>testram :tls :ram_init
@@ -203,7 +209,7 @@ SECTIONS
     PROVIDE( metal_segment_data_target_start = ADDR(.data) );
     PROVIDE( metal_segment_data_target_end = ADDR(.tdata) + SIZEOF(.tdata) );
 
-    .tbss : {
+    .tbss : ALIGN(8) {
 	*(.tbss .tbss.* .gnu.linkonce.tb.*)
 	*(.tcommon .tcommon.*)
 	PROVIDE( __tls_end = . );
@@ -211,7 +217,7 @@ SECTIONS
     PROVIDE( __tbss_size = SIZEOF(.tbss) );
     PROVIDE( __tls_size = __tls_end - __tls_base );
 
-    .tbss_space : {
+    .tbss_space : ALIGN(8) {
 	. = . + __tbss_size;
     } >testram :ram
 
@@ -237,13 +243,14 @@ SECTIONS
     } >testram :ram
 
     .heap (NOLOAD) : ALIGN(4) {
-	PROVIDE( __end = . );
+        PROVIDE( __end = . );
+        PROVIDE( __heap_start = . );
         PROVIDE( metal_segment_heap_target_start = . );
         /* If __heap_max is defined, grow the heap to use the rest of RAM,
          * otherwise set the heap size to __heap_size */
         . = DEFINED(__heap_max) ? MIN( LENGTH(ram) - ( . - ORIGIN(ram)) , 0x10000000) : __heap_size;
         PROVIDE( metal_segment_heap_target_end = . );
         PROVIDE( _heap_end = . );
-	PROVIDE( __heap_end = . );
+        PROVIDE( __heap_end = . );
     } >testram :ram
 }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/devicetree-overlay-generator.git"
     },
     {
-        "commit": "0fff38012af8ab7dc1715d08e5ff3456847ceb65",
+        "commit": "6d46316ade7996e37e85b6670d415b7e0497c3c8",
         "name": "ldscript-generator",
         "source": "git@github.com:sifive/ldscript-generator.git"
     },


### PR DESCRIPTION
- Adds the itim_init PHDR
- Aligns TLS sections to 8-byte boundaries for `_start`
- Provides symbols in the heap for picolibc's `sbrk`