### PR TITLE
sync threads to _enter before gdb resumes

### DIFF
--- a/scripts/upload
+++ b/scripts/upload
@@ -40,7 +40,7 @@ else
 
 $openocd -f $cfg &
 
-$gdb $elf --batch -ex "set remotetimeout 240" -ex "target extended-remote localhost:${GDB_PORT}" -ex "monitor reset halt" -ex "monitor flash protect 0 64 last off" -ex "load" -ex "monitor resume" -ex "monitor shutdown" -ex "quit"
+$gdb $elf --batch -ex "set remotetimeout 240" -ex "target extended-remote localhost:${GDB_PORT}" -ex "monitor reset halt" -ex "monitor flash protect 0 64 last off" -ex "thread apply all set \$pc=_enter" -ex "load" -ex "monitor resume" -ex "monitor shutdown" -ex "quit"
 
 kill %1
 


### PR DESCRIPTION
Add thread sync to _enter. Tested on single and multicore configs without issue.