### PR TITLE
Refactor and Add Wake API to Freedom E SDK

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -14,7 +14,7 @@ jobs:
           path: wit-packages/freedom-e-sdk
 
       - name: 'Init Wit Workspace'
-        uses: sifive/wit/actions/wit@v0.13.0
+        uses: sifive/wit/actions/wit@9fdc590
         with:
           command: init
           arguments: |
@@ -31,4 +31,4 @@ jobs:
             --workdir="/mnt/workspace" \
             --rm \
             sifive/environment-blockci:0.4.0
-            wake -v -x testFreedomESDKWakeAPI Unit
+            wake -v --in freedom_e_sdk_test -x testFreedomESDKWakeAPI Unit

--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -1,0 +1,34 @@
+name: wake-api-test
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      WIT_WORKSPACE: wit-workspace
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: wit-packages/freedom-e-sdk
+
+      - name: 'Init Wit Workspace'
+        uses: sifive/wit/actions/wit@v0.13.0
+        with:
+          command: init
+          arguments: |
+            ${{ env.WIT_WORKSPACE }}
+            -a ./wit-packages/freedom-e-sdk
+            -a git@github.com:sifive/environment-blockci-sifive.git::0.4.0
+          force_github_https: true
+
+      - name: 'Run Wake API Test'
+        run: |
+          set -euo pipefail
+          docker run \
+            --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
+            --workdir="/mnt/workspace" \
+            --rm \
+            sifive/environment-blockci:0.4.0
+            wake -v -x testFreedomESDKWakeAPI Unit

--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,12 @@ else
 endif
 
 # Default to use relase configuration For Benchmark programs, like Coremark and Dhrystone.
-ifeq ($(PROGRAM),dhrystone)
+ifeq ($(findstring dhrystone,$(PROGRAM)),dhrystone)
 CONFIGURATION = release
 endif
 
 # Coremark require PORT_DIR set for different OS, freedom-metal for us!
-ifeq ($(PROGRAM),coremark)
+ifeq ($(findstring coremark,$(PROGRAM)),coremark)
 CONFIGURATION = release
 ifeq ($(PORT_DIR),)
 PORT_DIR = freedom-metal

--- a/build.wake
+++ b/build.wake
@@ -63,39 +63,51 @@ def filterWakeAndDotFiles =
   | filter (!matches `.*\.wake` _.getPathName)
 
 #
-# Plan Resources
+# Build Environment
 #
+
+export tuple FreedomESDKBuildEnv =
+  export Resources: List String
+  export BuildDir: String
 
 export def defaultFreedomESDKResources =
   "riscv-tools/2019.08.0",
   "python/python/3.7.1",
   Nil
 
+export def defaultFreedomESDKBuildDir = "build/freedom-e-sdk"
+
+export def defaultFreedomESDKBuildEnv =
+  FreedomESDKBuildEnv defaultFreedomESDKResources defaultFreedomESDKBuildDir
+
 #
 # Virtualenv Creation
 #
 # Freedom E SDK depends on a number of Python libraries. Here we enable
-# the installation of a single, workspace-wide virtualenv which can be
-# preinstalled using either the `preinstallFreedomESDKVirtualenv` target
-# or the global `preinstall` topic. If the virtualenv has not been
-# preinstalled, it will be created on-demand when needed during the
-# creation of a `FreedomESDKTarget`.
+# the creation of a Virtualenv relative to the BuildDir of Freedom E SDK's
+# Build Environment. By default, these wake rules will ensure the creation
+# of this Virtualenv at run-time with `installFreedomESDKVirtualenv`.
+#
+# If your use-case requires that dependencies are fetched from the internet
+# at workspace creation time, make sure to add `installFreedomESDKVirualenv`
+# to the `preinstall` topic, substituting the FreedomESDKBuildEnv you want
+# to use.
 #
 
-export def freedomESDKBuildDir = "build/freedom-e-sdk"
-export def freedomESDKVenvDir = "{freedomESDKBuildDir}/venv"
+export def freedomESDKVenvDir buildEnv = "{buildEnv.getFreedomESDKBuildEnvBuildDir}/venv"
 
-def makeFreedomESDKVirtualenvJob Unit =
+def makeFreedomESDKVirtualenvJob buildEnv =
   def runDir = here
+  def resources = buildEnv.getFreedomESDKBuildEnvResources
 
   def inputs =
     source "freedom-e-sdk/scripts/virtualenv.mk",
     source "freedom-e-sdk/requirements.txt",
-    mkdir freedomESDKVenvDir,
+    mkdir (freedomESDKVenvDir buildEnv),
     Nil
 
   def cmd =
-    def venvDir = relative runDir freedomESDKVenvDir
+    def venvDir = relative runDir (freedomESDKVenvDir buildEnv)
     "bash", "-c", "%
       export FREEDOM_E_SDK_VENV_PATH=$(pwd)/%{venvDir}
       make -f scripts/virtualenv.mk virtualenv
@@ -107,23 +119,13 @@ def makeFreedomESDKVirtualenvJob Unit =
 
   makePlan cmd inputs
   | setPlanDirectory runDir
-  | setPlanResources defaultFreedomESDKResources
+  | setPlanResources resources
   | setPlanKeep True
-
-# preinstallFreedomESDKVirtualenv allows Freedom E SDK users to
-# preinstall the virtualenv in their workspace at the time of their
-# choosing with `wake -x preinstallFreedomESDKVirtualenv Unit`
-export target preinstallFreedomESDKVirtualenv Unit =
-  makeFreedomESDKVirtualenvJob Unit
-  | runJob
-  | getJobStderr
-
-publish preinstall = (preinstallFreedomESDKVirtualenv), Nil
 
 # Wake rules which depend upon the Freedom E SDK virtualenv should
 # add `installFreedomESDKVirtualenv` to their Plan inputs.
-export target installFreedomESDKVirtualenv Unit =
-  makeFreedomESDKVirtualenvJob Unit
+export target installFreedomESDKVirtualenv buildEnv =
+  makeFreedomESDKVirtualenvJob buildEnv
   | runJob
   | getJobOutputs
 
@@ -134,11 +136,12 @@ export target installFreedomESDKVirtualenv Unit =
 export tuple FreedomESDK =
   export Dir:            String
   export InstalledFiles: List Path
+  export BuildEnv: FreedomESDKBuildEnv
 
 # makeFreedomESDK assembles the components of Freedom E SDK into the directory
 # hierarchy expected by the SDK from their flat layout in the wit workspace.
 # The resulting sdk is located in {destDir}/freedom-e-sdk.
-export def makeFreedomESDK destDir =
+export def makeFreedomESDK buildEnv destDir =
   def sdkDir = "{destDir}/freedom-e-sdk"
   def scriptsDir = "{sdkDir}/scripts"
 
@@ -185,7 +188,7 @@ export def makeFreedomESDK destDir =
     ++ installOpenOCDConfigGenerator          scriptsDir
     ++ installESDKSettingsGenerator           scriptsDir
 
-  FreedomESDK sdkDir Nil
+  FreedomESDK sdkDir Nil buildEnv
   | setFreedomESDKInstalledFiles installedFiles
 
 #
@@ -226,12 +229,13 @@ def targetTypeToString = match _
 #                file generators.
 export def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
   def sdkDir = sdk.getFreedomESDKDir
+  def buildEnv = sdk.getFreedomESDKBuildEnv
   def bspDir = "{sdkDir}/bsp/{targetName}"
   def runDir = "{sdkDir}/bsp"
   def updateTargets = "{runDir}/update-targets.sh"
 
   def cmdline =
-    def venvPath = relative runDir freedomESDKVenvDir
+    def venvPath = relative runDir (freedomESDKVenvDir buildEnv)
     def updateTargetsScript = relative runDir updateTargets
     def fdtPath = relative runDir freedomDevicetreeToolsPath
     def targetDTS = relative runDir coreDTS.getPathName
@@ -252,7 +256,7 @@ export def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
     coreDTS,
     sdk.getFreedomESDKInstalledFiles
     ++ freedomDevicetreeToolsInstall Unit
-    ++ installFreedomESDKVirtualenv Unit
+    ++ installFreedomESDKVirtualenv buildEnv
 
   def fnOutputs _ =
     def alwaysOutputs =
@@ -277,7 +281,7 @@ export def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
 
   def installedFiles =
     makePlan cmdline inputs
-    | setPlanResources defaultFreedomESDKResources
+    | setPlanResources buildEnv.getFreedomESDKBuildEnvResources
     | setPlanFnOutputs fnOutputs
     | setPlanLocalOnly True
     | setPlanDirectory runDir
@@ -290,6 +294,7 @@ export def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
 def makeFreedomMetal sdkTarget =
   def sdk = sdkTarget.getFreedomESDKTargetSDK
   def sdkDir = sdk.getFreedomESDKDir
+  def buildEnv = sdk.getFreedomESDKBuildEnv
   def targetName = sdkTarget.getFreedomESDKTargetName
   def bspDir = "{sdkDir}/bsp/{targetName}"
 
@@ -315,7 +320,7 @@ def makeFreedomMetal sdkTarget =
 
   def installedFiles =
     makePlan cmdline inputs
-    | setPlanResources defaultFreedomESDKResources
+    | setPlanResources buildEnv.getFreedomESDKBuildEnvResources
     | setPlanFnOutputs fnOutputs
     | setPlanLocalOnly True
     | runJob
@@ -397,12 +402,13 @@ target makeProgram sdkTarget program =
 def makeProgramJob sdkTarget program =
   def sdk = sdkTarget.getFreedomESDKTargetSDK
   def sdkDir = sdk.getFreedomESDKDir
+  def buildEnv = sdk.getFreedomESDKBuildEnv
   def targetName = sdkTarget.getFreedomESDKTargetName
   def programName = program.getFreedomESDKProgramName
   def programSourceList = program.getFreedomESDKProgramSources
 
   def cmdline =
-    def venvPath = freedomESDKVenvDir
+    def venvPath = freedomESDKVenvDir buildEnv
     "bash", "-c", "%
       export FREEDOM_E_SDK_VENV_PATH=$(pwd)/%{venvPath}
       export FREERTOS_METAL_VENV_PATH=$(pwd)/%{venvPath}
@@ -418,7 +424,7 @@ def makeProgramJob sdkTarget program =
     def sdkInstall = sdk.getFreedomESDKInstalledFiles
     def targetInstall = sdkTarget.getFreedomESDKTargetInstalledFiles
     def programInstall = installFreedomESDKProgram sdk program
-    def virtualenvInstall = installFreedomESDKVirtualenv Unit
+    def virtualenvInstall = installFreedomESDKVirtualenv buildEnv
     sdkInstall
     ++ targetInstall
     ++ programInstall
@@ -427,7 +433,7 @@ def makeProgramJob sdkTarget program =
   def fnOutputs _ = files "{sdkDir}/software/{programName}/release" `[^/]*.(elf|hex)`
 
   makePlan cmdline inputs
-  | setPlanResources defaultFreedomESDKResources
+  | setPlanResources buildEnv.getFreedomESDKBuildEnvResources
   | setPlanFnOutputs fnOutputs
   | setPlanLocalOnly True
   | editPlanEnvironment ("RANLIB='riscv64-unknown-elf-ranlib -D'", _)

--- a/build.wake
+++ b/build.wake
@@ -94,6 +94,9 @@ export def defaultFreedomESDKBuildEnv =
 # to use.
 #
 
+export tuple FreedomESDKVirtualenv =
+  export InstalledFiles: List Path
+
 export def freedomESDKVenvDir buildEnv = "{buildEnv.getFreedomESDKBuildEnvBuildDir}/venv"
 
 def makeFreedomESDKVirtualenvJob buildEnv =
@@ -125,9 +128,11 @@ def makeFreedomESDKVirtualenvJob buildEnv =
 # Wake rules which depend upon the Freedom E SDK virtualenv should
 # add `installFreedomESDKVirtualenv` to their Plan inputs.
 export target installFreedomESDKVirtualenv buildEnv =
-  makeFreedomESDKVirtualenvJob buildEnv
-  | runJob
-  | getJobOutputs
+  def installedFiles =
+    makeFreedomESDKVirtualenvJob buildEnv
+    | runJob
+    | getJobOutputs
+  FreedomESDKVirtualenv installedFiles
 
 #
 # Freedom E SDK Installation
@@ -256,7 +261,7 @@ export def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
     coreDTS,
     sdk.getFreedomESDKInstalledFiles
     ++ freedomDevicetreeToolsInstall Unit
-    ++ installFreedomESDKVirtualenv buildEnv
+    ++ (installFreedomESDKVirtualenv buildEnv).getFreedomESDKVirtualenvInstalledFiles
 
   def fnOutputs _ =
     def alwaysOutputs =
@@ -424,11 +429,10 @@ def makeProgramJob sdkTarget program =
     def sdkInstall = sdk.getFreedomESDKInstalledFiles
     def targetInstall = sdkTarget.getFreedomESDKTargetInstalledFiles
     def programInstall = installFreedomESDKProgram sdk program
-    def virtualenvInstall = installFreedomESDKVirtualenv buildEnv
     sdkInstall
     ++ targetInstall
     ++ programInstall
-    ++ virtualenvInstall
+    ++ (installFreedomESDKVirtualenv buildEnv).getFreedomESDKVirtualenvInstalledFiles
 
   def fnOutputs _ = files "{sdkDir}/software/{programName}/release" `[^/]*.(elf|hex)`
 

--- a/build.wake
+++ b/build.wake
@@ -1,0 +1,430 @@
+#
+# Utility Functions
+#
+
+# This expects a sorted list of paths.
+# If a path is a prefix of the path that follows it, it is filtered out.
+def filterDirs sortedFiles =
+  def helper acc list = match list
+    head1, head2, tail =
+      def isPrefixOf path = matches (regExpCat (path.quote, `(/.+)?`, Nil))
+      if isPrefixOf head1 head2
+      then helper acc (head2, tail)
+      else helper (head1, acc) (head2, tail)
+    _ = list ++ acc
+  helper Nil sortedFiles
+  | reverse
+
+def getDestDirs srcDir destDir inputs =
+  def srcDirRegex = regExpCat (`^`, "{srcDir}/..".simplify.quote, `/+`, Nil)
+  inputs
+  | mapFlat (
+    _
+    | getPathName
+    | simplify
+    | replace srcDirRegex ""
+    | extract `(.*/)[^/]*`
+    | map ("{destDir}/{_}")
+  )
+  | distinctBy scmp
+
+def copyDir srcDir destDir fileInputs =
+  def dirInputs =
+    getDestDirs srcDir destDir fileInputs
+    | map mkdir
+  def inputs = dirInputs ++ fileInputs
+  def from_ = simplify "{srcDir}/.."
+  def srcs =
+    fileInputs
+    | map (
+      _
+      | getPathName
+      | from_.relative
+      | simplify
+    )
+    | filter (! matches `\.\./.*` _)
+    | sortBy (_ <~ _)
+    | filterDirs
+  def cmdline =
+    "rsync", "--inplace", "--relative",
+    "--ignore-times", srcs ++ (relative from_ destDir, Nil)
+  makePlan cmdline inputs
+  | setPlanDirectory from_
+  | runJob
+  | getJobOutputs
+
+def filterWakeAndDotFiles =
+  _
+  | filter (!matches `(.*/)*\..*` _.getPathName)
+  | filter (!matches `.*\.wake` _.getPathName)
+
+#
+# Plan Resources
+#
+
+global def defaultFreedomESDKResources =
+  "riscv-tools/2019.08.0",
+  "python/python/3.7.1",
+  Nil
+
+#
+# Virtualenv Creation
+#
+# Freedom E SDK depends on a number of Python libraries. Here we enable
+# the installation of a single, workspace-wide virtualenv which can be
+# preinstalled using either the `preinstallFreedomESDKVirtualenv` target
+# or the global `preinstall` topic. If the virtualenv has not been
+# preinstalled, it will be created on-demand when needed during the
+# creation of a `FreedomESDKTarget`.
+#
+
+global def freedomESDKBuildDir = "build/freedom-e-sdk"
+global def freedomESDKVenvDir = "{freedomESDKBuildDir}/venv"
+
+def makeFreedomESDKVirtualenvJob Unit =
+  def runDir = here
+
+  def inputs =
+    source "freedom-e-sdk/scripts/virtualenv.mk",
+    source "freedom-e-sdk/requirements.txt",
+    mkdir freedomESDKVenvDir,
+    Nil
+
+  def cmd =
+    def venvDir = relative runDir freedomESDKVenvDir
+    "bash", "-c", "%
+      export FREEDOM_E_SDK_VENV_PATH=$(pwd)/%{venvDir}
+      make -f scripts/virtualenv.mk virtualenv
+      # Remove e.g. .fuse/31337 from the paths in the virtualenv
+      find ${FREEDOM_E_SDK_VENV_PATH}/bin -type f | xargs sed -i 's%.fuse/[[:digit:]]\+/%%g'
+      # Remove e.g. .build/31337 from the paths in the virtualenv (when Wake doesn't use FUSE)
+      find ${FREEDOM_E_SDK_VENV_PATH}/bin -type f | xargs sed -i 's%.build/[[:digit:]]\+/%%g'
+      %", Nil
+
+  makePlan cmd inputs
+  | setPlanDirectory runDir
+  | setPlanResources defaultFreedomESDKResources
+  | setPlanKeep True
+
+# preinstallFreedomESDKVirtualenv allows Freedom E SDK users to
+# preinstall the virtualenv in their workspace at the time of their
+# choosing with `wake -x preinstallFreedomESDKVirtualenv Unit`
+global target preinstallFreedomESDKVirtualenv Unit =
+  makeFreedomESDKVirtualenvJob Unit
+  | runJob
+  | getJobStderr
+
+publish preinstall = (preinstallFreedomESDKVirtualenv), Nil
+
+# Wake rules which depend upon the Freedom E SDK virtualenv should
+# add `installFreedomESDKVirtualenv` to their Plan inputs.
+global target installFreedomESDKVirtualenv Unit =
+  makeFreedomESDKVirtualenvJob Unit
+  | runJob
+  | getJobOutputs
+
+#
+# Freedom E SDK Installation
+#
+
+global tuple FreedomESDK =
+  global Dir:            String
+  global InstalledFiles: List Path
+
+# makeFreedomESDK assembles the components of Freedom E SDK into the directory
+# hierarchy expected by the SDK from their flat layout in the wit workspace.
+# The resulting sdk is located in {destDir}/freedom-e-sdk.
+global def makeFreedomESDK destDir =
+  def sdkDir = "{destDir}/freedom-e-sdk"
+  def scriptsDir = "{sdkDir}/scripts"
+
+  def sdkSources =
+    source "freedom-e-sdk/bsp/update-targets.sh",
+    sources "freedom-e-sdk" `.*`
+    | filter (!matches `freedom-e-sdk/(freedom-devicetree-tools|freedom-metal|bsp|software|doc|pip-cache)(/.*)?` _.getPathName)
+    | filter (!matches `freedom-e-sdk/scripts/(elf2hex|devicetree-overlay-generator|ldscript-generator)(/.*)?` _.getPathName)
+    | filter (!matches `freedom-e-sdk/scripts/(cmsis-svd-generator|openocdcfg-generator|esdk-settings-generator)(/.*)?` _.getPathName)
+    | filterWakeAndDotFiles
+
+  def metalSources =
+    sources "freedom-metal" `.*`
+    | filter (!matches `freedom-metal/doc(/.*)?` _.getPathName)
+    | filterWakeAndDotFiles
+
+  def sifiveCryptoLibSources =
+    sources "scl-metal" `.*`
+    | filterWakeAndDotFiles
+
+  def freeRTOSSources =
+    sources "FreeRTOS-metal" `.*`
+    | filterWakeAndDotFiles
+
+  def systemViewSources =
+    sources "Segger_SystemView-metal" `.*`
+    | filterWakeAndDotFiles
+
+  def elf2hexSources =
+    sources "elf2hex" `.*`
+    | filterWakeAndDotFiles
+
+  def installedFiles = 
+    copyDir "freedom-e-sdk"                   destDir     sdkSources
+    ++ copyDir "freedom-metal"                sdkDir      metalSources
+    ++ copyDir "scl-metal"                    sdkDir      sifiveCryptoLibSources
+    ++ installFreedomDevicetreeTools          sdkDir
+    ++ copyDir "FreeRTOS-metal"               sdkDir      freeRTOSSources
+    ++ copyDir "Segger_SystemView-metal"      sdkDir      systemViewSources
+    ++ copyDir "elf2hex"                      scriptsDir  elf2hexSources
+    ++ installDevicetreeOverlayGenerator      scriptsDir
+    ++ installLdScriptGenerator               scriptsDir
+    ++ installSVDGenerator                    scriptsDir
+    ++ installOpenOCDConfigGenerator          scriptsDir
+    ++ installESDKSettingsGenerator           scriptsDir
+
+  FreedomESDK sdkDir Nil
+  | setFreedomESDKInstalledFiles installedFiles
+
+#
+# Freedom E SDK Target Creation
+#
+
+global tuple FreedomESDKTarget =
+  global SDK:            FreedomESDK
+  global Name:           String
+  global Type:           FreedomESDKTargetType
+  global InstalledFiles: List Path
+
+global data FreedomESDKTargetType =
+  RTLTargetType
+  ArtyTargetType
+  VC707TargetType
+  VCU118TargetType
+  QEMUTargetType
+  HiFiveTargetType
+  SpikeTargetType
+
+def targetTypeToString = match _
+  RTLTargetType  = "rtl"
+  ArtyTargetType = "arty"
+  VC707TargetType = "vc707"
+  VCU118TargetType = "vcu118"
+  QEMUTargetType = "qemu"
+  HiFiveTargetType = "hifive"
+  SpikeTargetType = "spike"
+
+# makeFreedomESDKTargetFromCoreDTS creates a FreedomESDKTarget given:
+#  - sdk: an instance of FreedomESDK, created by makeFreedomESDK
+#  - targetName: the name of the target as a String
+#  - coreDTS: a single Devicetree Source file which describes the hardware
+#             of the target device. This DTS will be used to generate a
+#             Devicetree Overlay
+#  - targetType: one of FreedomESDKTargetType, used to configure the BSP
+#                file generators.
+global def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
+  def sdkDir = sdk.getFreedomESDKDir
+  def bspDir = "{sdkDir}/bsp/{targetName}"
+  def runDir = "{sdkDir}/bsp"
+  def updateTargets = "{runDir}/update-targets.sh"
+
+  def cmdline =
+    def venvPath = relative runDir freedomESDKVenvDir
+    def updateTargetsScript = relative runDir updateTargets
+    def fdtPath = relative runDir freedomDevicetreeToolsPath
+    def targetDTS = relative runDir coreDTS.getPathName
+    def sdkPath = relative runDir sdkDir
+    "bash", "-c", "%
+      export PATH=$(pwd)/%{fdtPath}:$PATH
+      export FREEDOM_E_SDK_VENV_PATH=$(pwd)/%{venvPath}
+      touch ${FREEDOM_E_SDK_VENV_PATH}/.stamp
+      $(pwd)/%{updateTargetsScript} \
+        --target-name %{targetName} \
+        --target-dts=%{targetDTS} \
+        --sdk-path=%{sdkPath} \
+        --target-type %{targetType.targetTypeToString}
+      %", Nil
+
+  def inputs =
+    mkdir bspDir,
+    coreDTS,
+    sdk.getFreedomESDKInstalledFiles
+    ++ freedomDevicetreeToolsInstall Unit
+    ++ installFreedomESDKVirtualenv Unit
+
+  def fnOutputs _ =
+    def alwaysOutputs =
+      "{bspDir}/core.dts",
+      "{bspDir}/design.dts",
+      "{bspDir}/design.svd",
+      "{bspDir}/metal.h",
+      "{bspDir}/metal.default.lds",
+      "{bspDir}/metal.ramrodata.lds",
+      "{bspDir}/metal.scratchpad.lds",
+      "{bspDir}/metal.freertos.lds",
+      "{bspDir}/settings.mk",
+      "{bspDir}/metal-platform.h",
+      "{bspDir}/metal-inline.h",
+      Nil
+    match targetType
+      ArtyTargetType = "{bspDir}/openocd.cfg", alwaysOutputs
+      VC707TargetType = "{bspDir}/openocd.cfg", alwaysOutputs
+      VCU118TargetType = "{bspDir}/openocd.cfg", alwaysOutputs
+      HiFiveTargetType = "{bspDir}/openocd.cfg", alwaysOutputs
+      _ = alwaysOutputs
+
+  def installedFiles =
+    makePlan cmdline inputs
+    | setPlanResources defaultFreedomESDKResources
+    | setPlanFnOutputs fnOutputs
+    | setPlanLocalOnly True
+    | setPlanDirectory runDir
+    | runJob
+    | getJobOutputs
+
+  FreedomESDKTarget sdk targetName targetType installedFiles
+  | makeFreedomMetal
+
+def makeFreedomMetal sdkTarget =
+  def sdk = sdkTarget.getFreedomESDKTargetSDK
+  def sdkDir = sdk.getFreedomESDKDir
+  def targetName = sdkTarget.getFreedomESDKTargetName
+  def bspDir = "{sdkDir}/bsp/{targetName}"
+
+  def cmdline =
+    "bash", "-c", "%
+      make -C %{sdkDir} \
+        metal \
+        RANLIB='riscv64-unknown-elf-ranlib -D' \
+        ARFLAGS=Dcr \
+        CONFIGURATION=release \
+        TARGET=%{targetName}
+      %", Nil
+
+  def inputs =
+    sdk.getFreedomESDKInstalledFiles ++ sdkTarget.getFreedomESDKTargetInstalledFiles
+
+  def fnOutputs _ =
+    def bspDir = "{sdkDir}/bsp/{targetName}"
+    def libInstallDir = "{bspDir}/install/lib/release"
+    "{libInstallDir}/libmetal.a",
+    "{libInstallDir}/libmetal-gloss.a",
+    Nil
+
+  def installedFiles =
+    makePlan cmdline inputs
+    | setPlanResources defaultFreedomESDKResources
+    | setPlanFnOutputs fnOutputs
+    | setPlanLocalOnly True
+    | runJob
+    | getJobOutputs
+
+  sdkTarget
+  | editFreedomESDKTargetInstalledFiles (installedFiles ++ _)
+
+#
+# Program Install and Build
+#
+
+# installFreedomESDKProgram installs the FreedomESDKProgram sources
+# into the SDK
+global target installFreedomESDKProgram sdk program =
+  def dest = "{sdk.getFreedomESDKDir}/software"
+  def name = program.getFreedomESDKProgramName
+  def sourceDir = program.getFreedomESDKProgramSourceDir
+  def regex = regExpCat (sourceDir.quote, `/\..*`, Nil)
+  program.getFreedomESDKProgramSources
+  | filter (! matches regex _.getPathName)
+  | map (\p installAs (replace sourceDir.quote name "{dest}/{p.getPathName}") p)
+
+# Build an ELF of a FreedomESDKProgram for a FreedomESDKTarget
+global def makeFreedomESDKProgramHex sdkTarget program =
+  makeProgram sdkTarget program
+  | getPairSecond
+
+# Build a hex of a FreedomESDKProgram for a FreedomESDKTarget
+global def makeFreedomESDKProgramElf sdkTarget program =
+  makeProgram sdkTarget program
+  | getPairFirst
+
+# This rule can be used to detect when the build of a FreedomESDKProgram
+# fails for a given FreedomESDKTarget as a result of the program overflowing
+# some region of memory.
+global def freedomESDKProgramOverflowsMemory sdkTarget program =
+  def programJob = makeProgramJob sdkTarget program
+  def jobStderr = programJob.runJob.getJobStderr | getWhenFail ""
+  def sectionWillNotFit = `.*ld: .* section .* will not fit in region.*`
+  def regionOverflowed = `.*ld: region .* overflowed by .* bytes.*`
+
+  (matches sectionWillNotFit jobStderr) && (matches regionOverflowed jobStderr)
+
+# This rule can be used to detect when the build of a FreedomESDKProgram
+# fails for a given FreedomESDKTarget as a result of the memory layout
+# of the Target interacting with the default Freedom E SDK linker
+# scripts in a way which is incompatible with the available code models
+# in the RISC-V toolchain.
+global def freedomESDKProgramCannotLinkUnderCodeModel sdkTarget program =
+  def programJob = makeProgramJob sdkTarget program
+  def jobStderr = programJob.runJob.getJobStderr | getWhenFail ""
+  def relocationTruncated = `.*relocation truncated to fit.*`
+
+  matches relocationTruncated jobStderr
+
+target makeProgram sdkTarget program =
+  def targetName = sdkTarget.getFreedomESDKTargetName
+
+  def outputs =
+    makeProgramJob sdkTarget program
+    | runJob
+    | getJobOutputs
+
+  def filterFiles regex = filter (matches regex _.getPathName) outputs
+  def getFile regex = filterFiles regex | head
+  def elfResult = getFile `.*\.elf`
+  def hexResult = getFile `.*\.hex`
+
+  match elfResult hexResult
+    (Some elf) (Some hex) = Pair elf hex
+    _ _ =
+      def badPath =
+        "{targetName}: Unexpected software ouputs: {format outputs}"
+        .makeError
+        .makeBadPath
+      Pair badPath badPath
+
+def makeProgramJob sdkTarget program =
+  def sdk = sdkTarget.getFreedomESDKTargetSDK
+  def sdkDir = sdk.getFreedomESDKDir
+  def targetName = sdkTarget.getFreedomESDKTargetName
+  def programName = program.getFreedomESDKProgramName
+  def programSourceList = program.getFreedomESDKProgramSources
+
+  def cmdline =
+    def venvPath = freedomESDKVenvDir
+    "bash", "-c", "%
+      export FREEDOM_E_SDK_VENV_PATH=$(pwd)/%{venvPath}
+      export FREERTOS_METAL_VENV_PATH=$(pwd)/%{venvPath}
+      touch ${FREEDOM_E_SDK_VENV_PATH}/.stamp
+      make -C %{sdkDir} software \
+        ARFLAGS=Dcr \
+        CONFIGURATION=release \
+        TARGET=%{targetName} \
+        PROGRAM=%{programName}
+      %", Nil
+
+  def inputs =
+    def sdkInstall = sdk.getFreedomESDKInstalledFiles
+    def targetInstall = sdkTarget.getFreedomESDKTargetInstalledFiles
+    def programInstall = installFreedomESDKProgram sdk program
+    def virtualenvInstall = installFreedomESDKVirtualenv Unit
+    sdkInstall
+    ++ targetInstall
+    ++ programInstall
+    ++ virtualenvInstall
+
+  def fnOutputs _ = files "{sdkDir}/software/{programName}/release" `[^/]*.(elf|hex)`
+
+  makePlan cmdline inputs
+  | setPlanResources defaultFreedomESDKResources
+  | setPlanFnOutputs fnOutputs
+  | setPlanLocalOnly True
+  | editPlanEnvironment ("RANLIB='riscv64-unknown-elf-ranlib -D'", _)
+

--- a/build.wake
+++ b/build.wake
@@ -1,3 +1,7 @@
+package freedom_e_sdk
+
+from wake import _
+
 #
 # Utility Functions
 #
@@ -62,7 +66,7 @@ def filterWakeAndDotFiles =
 # Plan Resources
 #
 
-global def defaultFreedomESDKResources =
+export def defaultFreedomESDKResources =
   "riscv-tools/2019.08.0",
   "python/python/3.7.1",
   Nil
@@ -78,8 +82,8 @@ global def defaultFreedomESDKResources =
 # creation of a `FreedomESDKTarget`.
 #
 
-global def freedomESDKBuildDir = "build/freedom-e-sdk"
-global def freedomESDKVenvDir = "{freedomESDKBuildDir}/venv"
+export def freedomESDKBuildDir = "build/freedom-e-sdk"
+export def freedomESDKVenvDir = "{freedomESDKBuildDir}/venv"
 
 def makeFreedomESDKVirtualenvJob Unit =
   def runDir = here
@@ -109,7 +113,7 @@ def makeFreedomESDKVirtualenvJob Unit =
 # preinstallFreedomESDKVirtualenv allows Freedom E SDK users to
 # preinstall the virtualenv in their workspace at the time of their
 # choosing with `wake -x preinstallFreedomESDKVirtualenv Unit`
-global target preinstallFreedomESDKVirtualenv Unit =
+export target preinstallFreedomESDKVirtualenv Unit =
   makeFreedomESDKVirtualenvJob Unit
   | runJob
   | getJobStderr
@@ -118,7 +122,7 @@ publish preinstall = (preinstallFreedomESDKVirtualenv), Nil
 
 # Wake rules which depend upon the Freedom E SDK virtualenv should
 # add `installFreedomESDKVirtualenv` to their Plan inputs.
-global target installFreedomESDKVirtualenv Unit =
+export target installFreedomESDKVirtualenv Unit =
   makeFreedomESDKVirtualenvJob Unit
   | runJob
   | getJobOutputs
@@ -127,14 +131,14 @@ global target installFreedomESDKVirtualenv Unit =
 # Freedom E SDK Installation
 #
 
-global tuple FreedomESDK =
-  global Dir:            String
-  global InstalledFiles: List Path
+export tuple FreedomESDK =
+  export Dir:            String
+  export InstalledFiles: List Path
 
 # makeFreedomESDK assembles the components of Freedom E SDK into the directory
 # hierarchy expected by the SDK from their flat layout in the wit workspace.
 # The resulting sdk is located in {destDir}/freedom-e-sdk.
-global def makeFreedomESDK destDir =
+export def makeFreedomESDK destDir =
   def sdkDir = "{destDir}/freedom-e-sdk"
   def scriptsDir = "{sdkDir}/scripts"
 
@@ -188,13 +192,13 @@ global def makeFreedomESDK destDir =
 # Freedom E SDK Target Creation
 #
 
-global tuple FreedomESDKTarget =
-  global SDK:            FreedomESDK
-  global Name:           String
-  global Type:           FreedomESDKTargetType
-  global InstalledFiles: List Path
+export tuple FreedomESDKTarget =
+  export SDK:            FreedomESDK
+  export Name:           String
+  export Type:           FreedomESDKTargetType
+  export InstalledFiles: List Path
 
-global data FreedomESDKTargetType =
+export data FreedomESDKTargetType =
   RTLTargetType
   ArtyTargetType
   VC707TargetType
@@ -220,7 +224,7 @@ def targetTypeToString = match _
 #             Devicetree Overlay
 #  - targetType: one of FreedomESDKTargetType, used to configure the BSP
 #                file generators.
-global def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
+export def makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType =
   def sdkDir = sdk.getFreedomESDKDir
   def bspDir = "{sdkDir}/bsp/{targetName}"
   def runDir = "{sdkDir}/bsp"
@@ -326,7 +330,7 @@ def makeFreedomMetal sdkTarget =
 
 # installFreedomESDKProgram installs the FreedomESDKProgram sources
 # into the SDK
-global target installFreedomESDKProgram sdk program =
+export target installFreedomESDKProgram sdk program =
   def dest = "{sdk.getFreedomESDKDir}/software"
   def name = program.getFreedomESDKProgramName
   def sourceDir = program.getFreedomESDKProgramSourceDir
@@ -336,19 +340,19 @@ global target installFreedomESDKProgram sdk program =
   | map (\p installAs (replace sourceDir.quote name "{dest}/{p.getPathName}") p)
 
 # Build an ELF of a FreedomESDKProgram for a FreedomESDKTarget
-global def makeFreedomESDKProgramHex sdkTarget program =
+export def makeFreedomESDKProgramHex sdkTarget program =
   makeProgram sdkTarget program
   | getPairSecond
 
 # Build a hex of a FreedomESDKProgram for a FreedomESDKTarget
-global def makeFreedomESDKProgramElf sdkTarget program =
+export def makeFreedomESDKProgramElf sdkTarget program =
   makeProgram sdkTarget program
   | getPairFirst
 
 # This rule can be used to detect when the build of a FreedomESDKProgram
 # fails for a given FreedomESDKTarget as a result of the program overflowing
 # some region of memory.
-global def freedomESDKProgramOverflowsMemory sdkTarget program =
+export def freedomESDKProgramOverflowsMemory sdkTarget program =
   def programJob = makeProgramJob sdkTarget program
   def jobStderr = programJob.runJob.getJobStderr | getWhenFail ""
   def sectionWillNotFit = `.*ld: .* section .* will not fit in region.*`
@@ -361,7 +365,7 @@ global def freedomESDKProgramOverflowsMemory sdkTarget program =
 # of the Target interacting with the default Freedom E SDK linker
 # scripts in a way which is incompatible with the available code models
 # in the RISC-V toolchain.
-global def freedomESDKProgramCannotLinkUnderCodeModel sdkTarget program =
+export def freedomESDKProgramCannotLinkUnderCodeModel sdkTarget program =
   def programJob = makeProgramJob sdkTarget program
   def jobStderr = programJob.runJob.getJobStderr | getWhenFail ""
   def relocationTruncated = `.*relocation truncated to fit.*`

--- a/programs.wake
+++ b/programs.wake
@@ -1,14 +1,18 @@
-global tuple FreedomESDKProgram =
-  global Name: String
-  global Kind: String
-  global Sources: List Path
+package freedom_e_sdk
 
-global def getFreedomESDKProgramSourceDir program =
+from wake import _
+
+export tuple FreedomESDKProgram =
+  export Name: String
+  export Kind: String
+  export Sources: List Path
+
+export def getFreedomESDKProgramSourceDir program =
   def name = program.getFreedomESDKProgramName
   def kind = program.getFreedomESDKProgramKind
   "{kind}-{name}"
 
-global def makeFreedomESDKProgram name kind =
+export def makeFreedomESDKProgram name kind =
   def program = FreedomESDKProgram name kind Nil
   def sourceDir = program.getFreedomESDKProgramSourceDir
   def programSources = sources sourceDir `.*`
@@ -16,7 +20,7 @@ global def makeFreedomESDKProgram name kind =
   | setFreedomESDKProgramSources programSources
 
 # Get the list of Freedom E SDK examples which are compatible with a given target
-global def allFreedomESDKExamples sdkTarget =
+export def allFreedomESDKExamples sdkTarget =
   def programList =
     makeFreedomESDKProgram "hello" "example",
     makeFreedomESDKProgram "atomics" "example",
@@ -59,7 +63,7 @@ global def allFreedomESDKExamples sdkTarget =
   filterFreedomESDKPrograms sdkTarget programList
 
 # Get the list of Freedom E SDK benchmarks which are compatible with a given target
-global def allFreedomESDKBenchmarks sdkTarget =
+export def allFreedomESDKBenchmarks sdkTarget =
   def programList =
     makeFreedomESDKProgram "coremark" "benchmark",
     makeFreedomESDKProgram "dhrystone" "benchmark",
@@ -68,7 +72,7 @@ global def allFreedomESDKBenchmarks sdkTarget =
   filterFreedomESDKPrograms sdkTarget programList
 
 # Get all Freedom E SDK examples and benchmarks which are compatible with a given target
-global def allFreedomESDKPrograms sdkTarget =
+export def allFreedomESDKPrograms sdkTarget =
   allFreedomESDKExamples sdkTarget
   ++ allFreedomESDKBenchmarks sdkTarget
 

--- a/programs.wake
+++ b/programs.wake
@@ -94,7 +94,7 @@ def targetHasCompatible sdkTarget compatible =
   def inputs =
     source detectCompatible,
     sources "{targetBSPDir}" `.*\.dts`
-    ++ installFreedomESDKVirtualenv buildEnv
+    ++ (installFreedomESDKVirtualenv buildEnv).getFreedomESDKVirtualenvInstalledFiles
 
   def cmdline =
     def venvPath = freedomESDKVenvDir buildEnv

--- a/programs.wake
+++ b/programs.wake
@@ -1,0 +1,113 @@
+global tuple FreedomESDKProgram =
+  global Name: String
+  global Kind: String
+  global Sources: List Path
+
+global def getFreedomESDKProgramSourceDir program =
+  def name = program.getFreedomESDKProgramName
+  def kind = program.getFreedomESDKProgramKind
+  "{kind}-{name}"
+
+global def makeFreedomESDKProgram name kind =
+  def program = FreedomESDKProgram name kind Nil
+  def sourceDir = program.getFreedomESDKProgramSourceDir
+  def programSources = sources sourceDir `.*`
+  program
+  | setFreedomESDKProgramSources programSources
+
+# Get the list of Freedom E SDK examples which are compatible with a given target
+global def allFreedomESDKExamples sdkTarget =
+  def programList =
+    makeFreedomESDKProgram "hello" "example",
+    makeFreedomESDKProgram "atomics" "example",
+    makeFreedomESDKProgram "cflush" "example",
+    makeFreedomESDKProgram "clic-hardware-vector-interrupts" "example",
+    makeFreedomESDKProgram "clic-nested-interrupts" "example",
+    makeFreedomESDKProgram "clic-nonvector-interrupts" "example",
+    makeFreedomESDKProgram "clic-selective-vector-interrupts" "example",
+    makeFreedomESDKProgram "csr-access" "example",
+    makeFreedomESDKProgram "empty" "example",
+    makeFreedomESDKProgram "buserror" "example",
+    makeFreedomESDKProgram "freertos-blinky" "example",
+    makeFreedomESDKProgram "freertos-blinky-systemview" "example",
+    makeFreedomESDKProgram "freertos-minimal" "example",
+    makeFreedomESDKProgram "freertos-pmp-blinky" "example",
+    makeFreedomESDKProgram "hca-metal" "example",
+    makeFreedomESDKProgram "hpm" "example",
+    makeFreedomESDKProgram "i2c" "example",
+    makeFreedomESDKProgram "itim" "example",
+    makeFreedomESDKProgram "pmp" "example",
+    makeFreedomESDKProgram "pwm" "example",
+    makeFreedomESDKProgram "rtc" "example",
+    makeFreedomESDKProgram "spi" "example",
+    makeFreedomESDKProgram "user-mode" "example",
+    makeFreedomESDKProgram "user-syscall" "example",
+    makeFreedomESDKProgram "watchdog" "example",
+    makeFreedomESDKProgram "hello" "example",
+    makeFreedomESDKProgram "local-interrupt" "example",
+    makeFreedomESDKProgram "local-vector-interrupts" "example",
+    makeFreedomESDKProgram "minimal-boot" "example",
+    makeFreedomESDKProgram "multicore-hello" "example",
+    makeFreedomESDKProgram "plic-interrupts" "example",
+    makeFreedomESDKProgram "return-fail" "example",
+    makeFreedomESDKProgram "return-pass" "example",
+    makeFreedomESDKProgram "sifive-welcome" "example",
+    makeFreedomESDKProgram "software-interrupt" "example",
+    makeFreedomESDKProgram "timer-interrupt" "example",
+    makeFreedomESDKProgram "uart-interrupt" "example",
+    Nil
+  filterFreedomESDKPrograms sdkTarget programList
+
+# Get the list of Freedom E SDK benchmarks which are compatible with a given target
+global def allFreedomESDKBenchmarks sdkTarget =
+  def programList =
+    makeFreedomESDKProgram "coremark" "benchmark",
+    makeFreedomESDKProgram "dhrystone" "benchmark",
+    makeFreedomESDKProgram "mem-latency" "benchmark",
+    Nil
+  filterFreedomESDKPrograms sdkTarget programList
+
+# Get all Freedom E SDK examples and benchmarks which are compatible with a given target
+global def allFreedomESDKPrograms sdkTarget =
+  allFreedomESDKExamples sdkTarget
+  ++ allFreedomESDKBenchmarks sdkTarget
+
+def filterFreedomESDKPrograms sdkTarget programs =
+  def targetHasBusError = targetHasCompatible sdkTarget "sifive,buserror0"
+
+  programs
+  | filter (\p (! matches `.*buserror.*` p.getFreedomESDKProgramName) || targetHasBusError)
+  | filter (\p (! freedomESDKProgramOverflowsMemory sdkTarget p))
+  | filter (\p (! freedomESDKProgramCannotLinkUnderCodeModel sdkTarget p))
+
+def targetHasCompatible sdkTarget compatible =
+  def sdk = sdkTarget.getFreedomESDKTargetSDK
+  def detectCompatible = "{here}/scripts/detect_compatible.py"
+
+  def targetBSPDir = "{sdk.getFreedomESDKDir}/bsp/{sdkTarget.getFreedomESDKTargetName}"
+
+  def inputs =
+    source detectCompatible,
+    sources "{targetBSPDir}" `.*\.dts`
+    ++ installFreedomESDKVirtualenv Unit
+
+  def cmdline =
+    def venvPath = freedomESDKVenvDir
+    "bash", "-c", "%
+      . $(pwd)/%{venvPath}/bin/activate
+      touch %{targetBSPDir}/compatcheck
+      %{detectCompatible} \
+        --dts %{targetBSPDir}/design.dts \
+        --compatible %{compatible}
+      %", Nil
+
+  def jobStatus =
+    makePlan cmdline inputs
+    | setPlanResources defaultFreedomESDKResources
+    | setPlanLocalOnly True
+    | runJob
+    | getJobStatus
+
+  match jobStatus
+    Exited code = code == 0
+    _ = False

--- a/programs.wake
+++ b/programs.wake
@@ -86,6 +86,7 @@ def filterFreedomESDKPrograms sdkTarget programs =
 
 def targetHasCompatible sdkTarget compatible =
   def sdk = sdkTarget.getFreedomESDKTargetSDK
+  def buildEnv = sdk.getFreedomESDKBuildEnv
   def detectCompatible = "{here}/scripts/detect_compatible.py"
 
   def targetBSPDir = "{sdk.getFreedomESDKDir}/bsp/{sdkTarget.getFreedomESDKTargetName}"
@@ -93,10 +94,10 @@ def targetHasCompatible sdkTarget compatible =
   def inputs =
     source detectCompatible,
     sources "{targetBSPDir}" `.*\.dts`
-    ++ installFreedomESDKVirtualenv Unit
+    ++ installFreedomESDKVirtualenv buildEnv
 
   def cmdline =
-    def venvPath = freedomESDKVenvDir
+    def venvPath = freedomESDKVenvDir buildEnv
     "bash", "-c", "%
       . $(pwd)/%{venvPath}/bin/activate
       touch %{targetBSPDir}/compatcheck

--- a/scripts/detect_compatible.py
+++ b/scripts/detect_compatible.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+"""Detects the presence of a compatible string in a Devicetree"""
+
+import argparse
+import sys
+
+import pydevicetree
+
+def parse_arguments(argv):
+    arg_parser = argparse.ArgumentParser(
+        description="Detect the presence of a compatible string in a Devictree")
+
+    arg_parser.add_argument("-d", "--dts", required=True,
+        help="The path to the Devicteree for the target")
+    arg_parser.add_argument("-c", "--compatible", required=True,
+        help="The compatible string to check for")
+
+    return arg_parser.parse_args(argv)
+
+def main(argv):
+    parsed_args = parse_arguments(argv)
+
+    tree = pydevicetree.Devicetree.parseFile(
+            parsed_args.dts, followIncludes=True)
+
+    matches = tree.match(parsed_args.compatible)
+    if len(matches) != 0:
+        sys.stderr.write("Found {} matches for compatible string '{}'\n".format(len(matches), parsed_args.compatible))
+        sys.exit(0)
+
+    sys.stderr.write("Found no matches for compatible string '{}'\n".format(parsed_args.compatible))
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -63,7 +63,7 @@ ifeq ($(SPEC),)
 $(error RISCV_LIBC set to an unsupported value: $(RISCV_LIBC))
 endif
 
-ifeq ($(PROGRAM),dhrystone)
+ifeq ($(findstring dhrystone,$(PROGRAM)),dhrystone)
 ifeq ($(LINK_TARGET),)
   ifneq ($(TARGET),freedom-e310-arty)
   ifneq ($(TARGET),sifive-hifive1)
@@ -75,7 +75,7 @@ ifeq ($(LINK_TARGET),)
 endif
 endif
 
-ifeq ($(PROGRAM),coremark)
+ifeq ($(findstring coremark,$(PROGRAM)),coremark)
 ifeq ($(LINK_TARGET),)
 LINK_TARGET = ramrodata
 endif
@@ -154,7 +154,7 @@ RISCV_CXXFLAGS  += -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -mcmodel=$(RISCV_CMOD
 RISCV_ASFLAGS   += -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -mcmodel=$(RISCV_CMODEL)
 # Prune unused functions and data
 ifeq ($(RISCV_SERIES),sifive-8-series)
-ifeq ($(PROGRAM),dhrystone)
+ifeq ($(findstring dhrystone,$(PROGRAM)),dhrystone)
 RISCV_CFLAGS   += -fno-function-sections -fno-data-sections
 RISCV_CXXFLAGS += -fno-function-sections -fno-data-sections
 else
@@ -199,7 +199,7 @@ include $(CONFIGURATION).mk
 
 # Benchmark CFLAGS go after loading the CONFIGURATION so that they can override the optimization level
 
-ifeq ($(PROGRAM),dhrystone)
+ifeq ($(findstring dhrystone,$(PROGRAM)),dhrystone)
 ifeq ($(DHRY_OPTION),)
 # Ground rules (default)
 RISCV_XCFLAGS += -mexplicit-relocs -fno-inline
@@ -213,7 +213,7 @@ endif
 RISCV_XCFLAGS += -DDHRY_ITERS=$(TARGET_DHRY_ITERS)
 endif
 
-ifeq ($(PROGRAM),coremark)
+ifeq ($(findstring coremark,$(PROGRAM)),coremark)
 ifeq ($(RISCV_SERIES),sifive-8-series)
 # 8-series currently uses 7-series mtune, but this may change
 RISCV_XCFLAGS += -O2 -fno-common -funroll-loops -finline-functions -funroll-all-loops --param max-inline-insns-auto=20 -falign-functions=8 -falign-jumps=8 -falign-loops=8 --param inline-min-speedup=10 -mtune=sifive-7-series -ffast-math

--- a/scripts/virtualenv.mk
+++ b/scripts/virtualenv.mk
@@ -26,7 +26,7 @@ FREEDOM_E_SDK_PIP_CACHE_PATH ?= pip-cache
 
 $(FREEDOM_E_SDK_VENV_PATH)/bin/activate:
 	python3 -m venv $(FREEDOM_E_SDK_VENV_PATH)
-	. $@ && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install pip==20.0.1
+	. $@ && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install pip==20.0.1 --disable-pip-version-check
 
 .PHONY: pip-cache
 pip-cache: $(FREEDOM_E_SDK_PIP_CACHE_PATH)/.stamp
@@ -50,8 +50,8 @@ $(FREEDOM_E_SDK_VENV_PATH)/.stamp: $(FREEDOM_E_SDK_VENV_PATH)/bin/activate requi
 	@echo "FREEDOM_E_SDK_PIP_CACHE not found, creating virtualenv from Python Package Index" >&2
 	@echo "You can pre-download Python packages by running 'make pip-cache'."                >&2
 	@echo "################################################################################" >&2
-	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install pip==20.0.1
-	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install -r requirements.txt
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install pip==20.0.1 --disable-pip-version-check
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install -r requirements.txt --disable-pip-version-check
 	touch $@
 
 else # If FREEDOM_E_SDK_PIP_CACHE_PATH does exist, fetch dependences from there
@@ -63,7 +63,7 @@ $(FREEDOM_E_SDK_VENV_PATH)/.stamp: $(FREEDOM_E_SDK_VENV_PATH)/bin/activate requi
 	@echo "##################################################################" >&2
 	@echo "FREEDOM_E_SDK_PIP_CACHE found, creating virtualenv from $(FREEDOM_E_SDK_PIP_CACHE_PATH)" >&2
 	@echo "##################################################################" >&2
-	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install --no-index --find-links $(FREEDOM_E_SDK_PIP_CACHE_PATH) -r requirements.txt
+	. $< && $(FREEDOM_E_SDK_VENV_PATH)/bin/python3 $(FREEDOM_E_SDK_VENV_PATH)/bin/pip install --no-index --find-links $(FREEDOM_E_SDK_PIP_CACHE_PATH) -r requirements.txt --disable-pip-version-check
 	touch $@
 
 endif # FREEDOM_E_SDK_PIP_CACHE_PATH

--- a/test-wake-api.wake
+++ b/test-wake-api.wake
@@ -1,0 +1,43 @@
+
+# This target tests the Freedom E SDK Wake API by
+#  1. Installing the SDK using the Wake API
+#  2. Creating a new target with the qemu-sifive-e31 core.dts
+#  3. Building allFreedomESDKPrograms
+#  4. Checking to make sure all programs built ELFs successfully
+global target testFreedomESDKWakeAPI Unit =
+  # Install Freedom E SDK into destDir
+  def destDir = "build/freedom-e-sdk/test-wake"
+  def sdk = makeFreedomESDK destDir
+
+  def targetName = "qemu-sifive-e31"
+  def coreDTS = source "{here}/bsp/{targetName}/core.dts"
+  def targetType = QEMUTargetType
+
+  # QEMU targets need qemu.cfg installed with them in order to simulate. This test
+  # doesn't currently try to run simulation, but I'm installing the necessary file
+  # here for completeness and to demonstrate how to add additional files to installed
+  # `FreedomESDKTarget`s.
+  def qemuCfg = source "{here}/bsp/{targetName}/qemu.cfg"
+
+  def sdkTarget =
+    def installedQEMUCfg =
+      installAs "{destDir}/freedom-e-sdk/bsp/{targetName}/qemu.cfg" qemuCfg
+    makeFreedomESDKTargetFromCoreDTS sdk targetName coreDTS targetType
+    | editFreedomESDKTargetInstalledFiles (installedQEMUCfg, _)
+
+  # Get the programs for the target
+  def programs = allFreedomESDKPrograms sdkTarget
+
+  def results =
+    def programs = allFreedomESDKPrograms sdkTarget
+    def programELFs = map (\p makeFreedomESDKProgramElf sdkTarget p) programs
+    # map to List Result and reduce to a Result
+    map getPathResult programELFs
+    | findFail
+
+  # Pretty-print results
+  match results
+    Pass paths =
+      def _ = map (\p println p.getPathName) paths
+      Pass "All ELFs built successfully for {targetName}"
+    Fail error = Fail error

--- a/test-wake-api.wake
+++ b/test-wake-api.wake
@@ -1,10 +1,14 @@
+package freedom_e_sdk_test
+
+from wake import _
+from freedom_e_sdk import _
 
 # This target tests the Freedom E SDK Wake API by
 #  1. Installing the SDK using the Wake API
 #  2. Creating a new target with the qemu-sifive-e31 core.dts
 #  3. Building allFreedomESDKPrograms
 #  4. Checking to make sure all programs built ELFs successfully
-global target testFreedomESDKWakeAPI Unit =
+export target testFreedomESDKWakeAPI Unit =
   # Install Freedom E SDK into destDir
   def destDir = "build/freedom-e-sdk/test-wake"
   def sdk = makeFreedomESDK destDir

--- a/test-wake-api.wake
+++ b/test-wake-api.wake
@@ -11,7 +11,7 @@ from freedom_e_sdk import _
 export target testFreedomESDKWakeAPI Unit =
   # Install Freedom E SDK into destDir
   def destDir = "build/freedom-e-sdk/test-wake"
-  def sdk = makeFreedomESDK destDir
+  def sdk = makeFreedomESDK defaultFreedomESDKBuildEnv destDir
 
   def targetName = "qemu-sifive-e31"
   def coreDTS = source "{here}/bsp/{targetName}/core.dts"

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,5 +1,10 @@
 [
     {
+        "commit": "e46103f52166bfde4ba33ff048937b896e6235d1",
+        "name": "api-languages-sifive",
+        "source": "git@github.com:sifive/api-languages-sifive.git"
+    },
+    {
         "commit": "db4ba0f4a25cee3f892e48c4fe3b58570f148290",
         "name": "freedom-devicetree-tools",
         "source": "git@github.com:sifive/freedom-devicetree-tools.git"


### PR DESCRIPTION
Here is my proposal for bringing the Freedom E SDK Wake API into Freedom E SDK. In doing so, I've also made some modifications in service of improving, clarifying, and making the API more maintainable.

### FreedomESDKTarget

`FreedomESDKTarget` is now the tuple for adding targets to Freedom E SDK and building programs. A `FreedomESDKTarget` can be created with `makeFreedomESDKTargetFromCoreDTS`, which I've named to clarify that we generate the design.dts overlay ourselves and to permit the creation of new APIs which provide the Devicetree overlay in the future. The comment/"function signature" from the code is reproduced below:

```
# makeFreedomESDKTargetFromCoreDTS creates a FreedomESDKTarget given:
#  - sdk: an instance of FreedomESDK, created by makeFreedomESDK
#  - targetName: the name of the target as a String
#  - coreDTS: a single Devicetree Source file which describes the hardware
#             of the target device. This DTS will be used to generate a
#             Devicetree Overlay
#  - targetType: one of FreedomESDKTargetType, used to configure the BSP
#                file generators.
```

Consumers of the Freedom E SDK Wake API will need to do one of the following to use Freedom E SDK:
 1. Adopt `FreedomESDKTarget` as their representation of their build targets (probably least likely or appropriate).
 2. Wrap `FreedomESDKTarget` in their own build target representation.
 3. Define a mapping between their own build target representation and `FreedomESDKTarget`.

### FreedomESDKProgram

Freedom E SDK now owns the list of programs it can build and imposes its own filtering rules when queried for that list of programs. Note in programs.wake:

```
# Get the list of Freedom E SDK examples which are compatible with a given target
global def allFreedomESDKExamples sdkTarget =
  def programList =
    makeFreedomESDKProgram "hello" "example",
    ... TRUNCATED ...
    makeFreedomESDKProgram "uart-interrupt" "example",
    Nil
  filterFreedomESDKPrograms sdkTarget programList
```

The list of examples is a function of the `FreedomESDKTarget`. This reduces the risk that someone will attempt to build an example which is incompatible with the target. Consumers of this API can optionally extend or additionally filter the returned list of programs, or ignore the list entirely.