### PR TITLE
Bump tests to picolibc 1.4.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04 AS download-tarballs
 
 ARG RISCV_TOOLS_TARBALL=riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz
-ARG RISCV_PICOLIBC_TARBALL=riscv64-unknown-elf-picolibc-1.4.1-2019.08.0-x86_64-linux-ubuntu14.tar.gz
+ARG RISCV_PICOLIBC_TARBALL=riscv64-unknown-elf-picolibc-1.4.6-2019.08.0-x86_64-linux-ubuntu14.tar.gz
 ARG QEMU_TARBALL=riscv-qemu-4.1.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz
 
 RUN apt-get update && \
@@ -11,7 +11,7 @@ RUN apt-get update && \
     wget
 
 # Install picolibc
-RUN wget --no-verbose https://github.com/keith-packard/picolibc/releases/download/1.4.1/${RISCV_PICOLIBC_TARBALL} && \
+RUN wget --no-verbose https://github.com/keith-packard/picolibc/releases/download/1.4.6/${RISCV_PICOLIBC_TARBALL} && \
     tar xzf ${RISCV_PICOLIBC_TARBALL}
 
 # Install RISC-V Toolchain


### PR DESCRIPTION
Bump the version of picolibc used in the Docker container test environment to 1.4.6 from version 1.4.1.