### PR TITLE
Remove ecc scrub memory labels.

### DIFF
--- a/bsp/freedom-e310-arty/metal.default.lds
+++ b/bsp/freedom-e310-arty/metal.default.lds
@@ -72,15 +72,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
-    PROVIDE( metal_itim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_itim_0_memory_end = 0x8000000 + 0x4000 );
 
     /* ROM SECTION
      *

--- a/bsp/freedom-e310-arty/metal.freertos.lds
+++ b/bsp/freedom-e310-arty/metal.freertos.lds
@@ -75,15 +75,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
-    PROVIDE( metal_itim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_itim_0_memory_end = 0x8000000 + 0x4000 );
 
     /* ROM SECTION
      *

--- a/bsp/freedom-e310-arty/metal.ramrodata.lds
+++ b/bsp/freedom-e310-arty/metal.ramrodata.lds
@@ -76,15 +76,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
-    PROVIDE( metal_itim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_itim_0_memory_end = 0x8000000 + 0x4000 );
 
     /* ROM SECTION
      *

--- a/bsp/freedom-e310-arty/metal.scratchpad.lds
+++ b/bsp/freedom-e310-arty/metal.scratchpad.lds
@@ -73,7 +73,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-e31/metal.default.lds
+++ b/bsp/qemu-sifive-e31/metal.default.lds
@@ -71,15 +71,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-e31/metal.freertos.lds
+++ b/bsp/qemu-sifive-e31/metal.freertos.lds
@@ -74,15 +74,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-e31/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-e31/metal.ramrodata.lds
@@ -75,15 +75,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-e31/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-e31/metal.scratchpad.lds
@@ -72,7 +72,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-s51/metal.default.lds
+++ b/bsp/qemu-sifive-s51/metal.default.lds
@@ -71,15 +71,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-s51/metal.freertos.lds
+++ b/bsp/qemu-sifive-s51/metal.freertos.lds
@@ -74,15 +74,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-s51/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-s51/metal.ramrodata.lds
@@ -75,15 +75,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-s51/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-s51/metal.scratchpad.lds
@@ -72,7 +72,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54/metal.default.lds
+++ b/bsp/qemu-sifive-u54/metal.default.lds
@@ -70,15 +70,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54/metal.freertos.lds
+++ b/bsp/qemu-sifive-u54/metal.freertos.lds
@@ -73,15 +73,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-u54/metal.ramrodata.lds
@@ -74,15 +74,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-u54/metal.scratchpad.lds
@@ -71,7 +71,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54mc/metal.default.lds
+++ b/bsp/qemu-sifive-u54mc/metal.default.lds
@@ -70,15 +70,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54mc/metal.freertos.lds
+++ b/bsp/qemu-sifive-u54mc/metal.freertos.lds
@@ -73,15 +73,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54mc/metal.ramrodata.lds
+++ b/bsp/qemu-sifive-u54mc/metal.ramrodata.lds
@@ -74,15 +74,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/qemu-sifive-u54mc/metal.scratchpad.lds
+++ b/bsp/qemu-sifive-u54mc/metal.scratchpad.lds
@@ -71,7 +71,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive-unleashed/metal.default.lds
+++ b/bsp/sifive-hifive-unleashed/metal.default.lds
@@ -72,27 +72,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x1000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x1000000 + 0x2000 );
-    PROVIDE( metal_itim_0_memory_start = 0x1800000 );
-    PROVIDE( metal_itim_0_memory_end = 0x1800000 + 0x4000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_itim_1_memory_start = 0x1808000 );
-    PROVIDE( metal_itim_1_memory_end = 0x1808000 + 0x10000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_lim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_lim_0_memory_end = 0x8000000 + 0x10000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive-unleashed/metal.freertos.lds
+++ b/bsp/sifive-hifive-unleashed/metal.freertos.lds
@@ -75,27 +75,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x1000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x1000000 + 0x2000 );
-    PROVIDE( metal_itim_0_memory_start = 0x1800000 );
-    PROVIDE( metal_itim_0_memory_end = 0x1800000 + 0x4000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_itim_1_memory_start = 0x1808000 );
-    PROVIDE( metal_itim_1_memory_end = 0x1808000 + 0x10000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_lim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_lim_0_memory_end = 0x8000000 + 0x10000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive-unleashed/metal.ramrodata.lds
+++ b/bsp/sifive-hifive-unleashed/metal.ramrodata.lds
@@ -76,27 +76,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x1000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x1000000 + 0x2000 );
-    PROVIDE( metal_itim_0_memory_start = 0x1800000 );
-    PROVIDE( metal_itim_0_memory_end = 0x1800000 + 0x4000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_itim_1_memory_start = 0x1808000 );
-    PROVIDE( metal_itim_1_memory_end = 0x1808000 + 0x10000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_lim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_lim_0_memory_end = 0x8000000 + 0x10000 );
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive-unleashed/metal.scratchpad.lds
+++ b/bsp/sifive-hifive-unleashed/metal.scratchpad.lds
@@ -73,7 +73,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1-revb/metal.default.lds
+++ b/bsp/sifive-hifive1-revb/metal.default.lds
@@ -72,15 +72,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
-    PROVIDE( metal_itim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_itim_0_memory_end = 0x8000000 + 0x2000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1-revb/metal.freertos.lds
+++ b/bsp/sifive-hifive1-revb/metal.freertos.lds
@@ -75,15 +75,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
-    PROVIDE( metal_itim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_itim_0_memory_end = 0x8000000 + 0x2000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1-revb/metal.ramrodata.lds
+++ b/bsp/sifive-hifive1-revb/metal.ramrodata.lds
@@ -76,15 +76,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
-    PROVIDE( metal_itim_0_memory_start = 0x8000000 );
-    PROVIDE( metal_itim_0_memory_end = 0x8000000 + 0x2000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1-revb/metal.scratchpad.lds
+++ b/bsp/sifive-hifive1-revb/metal.scratchpad.lds
@@ -73,7 +73,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1/metal.default.lds
+++ b/bsp/sifive-hifive1/metal.default.lds
@@ -71,13 +71,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1/metal.freertos.lds
+++ b/bsp/sifive-hifive1/metal.freertos.lds
@@ -74,13 +74,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1/metal.ramrodata.lds
+++ b/bsp/sifive-hifive1/metal.ramrodata.lds
@@ -75,13 +75,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    PROVIDE( metal_dtim_0_memory_start = 0x80000000 );
-    PROVIDE( metal_dtim_0_memory_end = 0x80000000 + 0x4000 );
 
     /* ROM SECTION
      *

--- a/bsp/sifive-hifive1/metal.scratchpad.lds
+++ b/bsp/sifive-hifive1/metal.scratchpad.lds
@@ -72,7 +72,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/bsp/spike/metal.default.lds
+++ b/bsp/spike/metal.default.lds
@@ -70,15 +70,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/spike/metal.freertos.lds
+++ b/bsp/spike/metal.freertos.lds
@@ -73,15 +73,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/spike/metal.ramrodata.lds
+++ b/bsp/spike/metal.ramrodata.lds
@@ -74,15 +74,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    /* The memory_ecc_scrub bit is used by _entry code to enable/disable
-     * memories scrubbing to zero  */
-    PROVIDE(__metal_eccscrub_bit = 0);
-
-    /* The RAM memories map for ECC scrubbing */
-    /* Default zero-scrub to at most 64KB, for limiting RTL simulation run time. */
-    /* User is recommended to enable the full size for manual RTL simulation run! */
-    PROVIDE( metal_memory_0_memory_start = 0x80000000 );
-    PROVIDE( metal_memory_0_memory_end = 0x80000000 + 0x10000 );
 
     /* ROM SECTION
      *

--- a/bsp/spike/metal.scratchpad.lds
+++ b/bsp/spike/metal.scratchpad.lds
@@ -71,7 +71,6 @@ SECTIONS
      * certain core features */
     PROVIDE(__metal_chicken_bit = 1);
 
-    PROVIDE(__metal_eccscrub_bit = 0);
 
     /* ROM SECTION
      *

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/devicetree-overlay-generator.git"
     },
     {
-        "commit": "693073ebafee5b81b2b67f40fafbcaea7723f345",
+        "commit": "b93d782115b39e9ce3ac774869f40bf6b5e50cdd",
         "name": "ldscript-generator",
         "source": "git@github.com:sifive/ldscript-generator.git"
     },


### PR DESCRIPTION
Remove unused scrub memory labels from linker scripts.

