### PR TITLE
Update README with correct default TARGET

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,12 +296,12 @@ export FREEDOM_E_SDK_VENV_PATH=/path/to/venv
 To compile a bare-metal RISC-V program:
 
 ```
-make [PROGRAM=hello] [TARGET=sifive-hifive1] [CONFIGURATION=debug] software
+make [PROGRAM=hello] [TARGET=freedom-e310-arty] [CONFIGURATION=debug] software
 ```
 
 The square brackets in the above command indicate optional parameters for the
 Make invocation. As you can see, the default values of these parameters tell
-the build script to build the `hello` example for the `sifive-hifive1` target
+the build script to build the `hello` example for the `freedom-e310-arty` target
 with the `debug` configuration. If, for example, you wished to build the
 `timer-interrupt` example for the S51 Arty FPGA Evaluation target,
 with the `release` configuration, you would instead run the command


### PR DESCRIPTION
On my workstation, this little gemstone
```
TARGET ?= $(shell find $(TARGET_ROOT)/bsp/* -type d | head -n 1 | rev | cut -d '/' -f 1 | rev)
```
currently selects `freedom-e310-arty`, contradicting README.md.

This behavior is apparently determined by the current population of the `bsp` subdirectory, so future revisions of FESDK could inadvertently re-break this. (I suspect this behavior is also shell dependent.) 