### PR TITLE
correct wrong name for demo application

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ on some examples.
 Here is an exemple of use :
 
 ```
-make PROGRAM=example-freertos-blinky-pmp TARGET=sifive-hifive1-revb LINK_TARGET=freertos software
+make PROGRAM=example-freertos-pmp-blinky TARGET=sifive-hifive1-revb LINK_TARGET=freertos software
 ```
 
 #### Uploading to the Target Board ####


### PR DESCRIPTION
there was typo in the description on how to generate FreeRTOS demo project in README.md file. 


