### PR TITLE
fixed bug id #567 - fixed make issue while  creating doc

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, SiFive Inc.'
 author = 'SiFive Inc.'
 
 # The short X.Y version
-version = os.environ['RELEASE_TAG']
+#version = os.environ['RELEASE_TAG']
 # The full version, including alpha/beta/rc tags
-release = version
+#release = version
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
There is a keyError for RELEASE_TAG variable

because there is no environ variable with key name RELEASE_TAG

code:

os.environ['RELEASE_TAG'] in /usr/lib/python3/dist-packages/sphinx/config.py is trying to fetch the RELEASE_TAG variable value , which is not present in os.environ

so it is throwing KeyError: 'RELEASE_TAG'

solution :

I commented these two lines and run make
it works

#version = os.environ['RELEASE_TAG']
#release = version