### PR TITLE
add semihost library support

### DIFF
--- a/scripts/standalone.mk
+++ b/scripts/standalone.mk
@@ -60,6 +60,13 @@ METAL_WITH_EXTRA=--with-builtin-libgloss
 SPEC=nano
 endif
 
+ifeq ($(RISCV_LIBC),semihost)
+# semihost must come before metal-gloss
+LIBMETAL_EXTRA=-lsemihost -lmetal-gloss 
+METAL_WITH_EXTRA=--with-builtin-libgloss
+SPEC=semihost
+endif
+
 ifeq ($(SPEC),)
 $(error RISCV_LIBC set to an unsupported value: $(RISCV_LIBC))
 endif


### PR DESCRIPTION
GCC-10.2.0-2020.12.8 include a functional semihost library.  This change allows freedom-e-sdk standalone projects to build example using this library by providing `RISCV_LIBC=semihost` 

This has been tested in Freedom Studio.  Freedom Studio only offers the `semihost` option if the chosen toolchain has a semihost library present in the installation.  

![Snag_4fbe006](https://user-images.githubusercontent.com/43148204/108536056-d63b4e00-7290-11eb-94a6-501e1d4266d9.png)
