### PR TITLE
add remote container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:20.04
+
+ARG USER
+
+RUN apt update
+RUN export DEBIAN_FRONTEND=noninteractive && apt install -y locales sudo
+
+ENV ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt install -y nano git bash-completion bc curl python3 python3-pip python3-venv
+
+RUN curl https://static.dev.sifive.com/dev-tools/riscv-openocd-0.10.0-2020.04.6-x86_64-linux-ubuntu14.tar.gz -o /root/openocd.tar.gz \
+    && tar -zxvf /root/openocd.tar.gz -C /root --one-top-level=openocd --strip-components=1
+
+RUN curl https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz -o /root/gnu-tools.tar.gz \
+    && tar -zxvf /root/gnu-tools.tar.gz -C /root --one-top-level=gnu-tools --strip-components=1
+
+ENV RISCV_OPENOCD_PATH /root/openocd
+ENV RISCV_PATH /root/gnu-tools
+
+RUN useradd -m -s /bin/bash felix
+
+USER ${USER}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.158.0/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"USER": "${localEnv:USER}"
+		}
+	},
+
+	"runArgs": ["--privileged",  "-v/dev/bus/usb:/dev/bus/usb"],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	"remoteUser": "${localEnv:USER}"
+}


### PR DESCRIPTION
I've prototyped a quick demo for how to utilize vs code remote containers with freedom-e-sdk.

Benefits that I see:
* lower barrier of entry
* reduced boilerplate
* sandboxed build environment

Would it be possible to add something similar? 