### PR TITLE
GitHub Actions: update our test and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,12 @@ jobs:
           git reset --hard origin/master
           rm -rf * .buildinfo .doctrees
 
+      - name: 'Login to Docker Hub'
+        uses: docker/login-action@v1.9.0
+        with:
+         username: ${{ secrets.DOCKERHUB_USERNAME }}
+         password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: 'Build Sphinx Documenattion'
         run: |
           tag=$(echo ${{ github.ref }} | cut -d '/' -f 3)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: freedom-e-sdk
+          fetch-depth: 1
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: 'Clone Segger libc'
         uses: actions/checkout@v2
@@ -29,9 +32,11 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           path: freedom-e-sdk/segger-libc
 
-      - name: 'Checkout submodules'
-        run: |
-          git -C freedom-e-sdk submodule update --init --recursive --depth=1
+      - name: 'Login to Docker Hub'
+        uses: docker/login-action@v1.9.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 'Build freedom-e-sdk container'
         run: |


### PR DESCRIPTION
Update our GitHub Actions test and release workflows to log into
Docker Hub to avoid rate limiting, and to change the way we check out
submodules.