### PR TITLE
GitHub tests: drop SEGGER libc from the list of CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
         ]
         riscv_libc: [
           "",
-          "segger",
         ]
 
     steps:
@@ -24,13 +23,6 @@ jobs:
           fetch-depth: 1
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-
-      - name: 'Clone Segger libc'
-        uses: actions/checkout@v2
-        with:
-          repository: sifive/freedom-e-sdk-ci-segger-libc
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          path: freedom-e-sdk/segger-libc
 
       - name: 'Login to Docker Hub'
         uses: docker/login-action@v1.9.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:16.04 AS download-tarballs
 ARG SIFIVE_TOOLS_URL=https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.08
 
 ARG RISCV_TOOLS_TARBALL=riscv64-unknown-elf-gcc-10.1.0-2020.08.2-x86_64-linux-ubuntu14.tar.gz
-ARG RISCV_SEGGER_LIBC_TARBALL=segger_libc-2020.08.2.tar.bz2
 ARG QEMU_TARBALL=riscv-qemu-5.1.0-2020.08.1-x86_64-linux-ubuntu14.tar.gz
 
 RUN apt-get update && \
@@ -18,12 +17,6 @@ RUN wget --no-verbose ${SIFIVE_TOOLS_URL}/${RISCV_TOOLS_TARBALL} && \
     tar xzf ${RISCV_TOOLS_TARBALL} && \
     mkdir -p /tools && \
     rsync -a ${RISCV_TOOLS_TARBALL%.tar.gz}/* /tools/
-
-# Install Segger libc
-COPY ./segger-libc/${RISCV_SEGGER_LIBC_TARBALL} ./
-RUN tar xjf ${RISCV_SEGGER_LIBC_TARBALL} && \
-    cd ${RISCV_SEGGER_LIBC_TARBALL%.tar.bz2} && \
-    RISCV_TOOL_PATH=/tools ./libc_segger_install.sh
 
 # Install QEMU
 RUN wget --no-verbose ${SIFIVE_TOOLS_URL}/${QEMU_TARBALL} && \


### PR DESCRIPTION
We don't support SEGGER libc in the public Freedom E SDK, so let's remove
it from the list of CI jobs.