### PR TITLE
Dockerfile: add 'bc' to the list of packages to install in the test i…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
     apt-get install -y \
     bzip2 \
     rsync \
-    wget
+    wget \
+    bc
 
 # Install RISC-V Toolchain
 RUN wget --no-verbose ${SIFIVE_TOOLS_URL}/${RISCV_TOOLS_TARBALL} && \


### PR DESCRIPTION
…nstance

'bc' is required by the build, but it's not actually listed in the
dependencies.  'bc'-related errors have apparently been ignored so far