### PR TITLE
Update design.svd

### DIFF
--- a/bsp/sifive-hifive-unmatched/design.svd
+++ b/bsp/sifive-hifive-unmatched/design.svd
@@ -4,7 +4,7 @@
   <version>0.1</version>
   <description>From sifive,hifive-unmatched-a00,model device generator</description>
   <addressUnitBits>8</addressUnitBits>
-  <width>32</width>
+  <width>64</width>
   <size>32</size>
   <access>read-write</access>
   <peripherals>


### PR DESCRIPTION
According to https://www.keil.com/pack/doc/CMSIS/SVD/html/svd_Example_pg.html, the `width` field represents "system bus width".  Shouldn't this value be 64 for the fu-740?