### PR TITLE
Add build dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.dtb
 venv/
 pip-cache/
+bsp/*/build/
+bsp/*/install/
+software/*/debug/


### PR DESCRIPTION
These are directories generated when building various example images.

TEST='git status' does not show generated directories any more